### PR TITLE
Fix for issue #100: test_sync_users can fail if the codebase has the 'de' language present

### DIFF
--- a/local/o365/tests/usersync_test.php
+++ b/local/o365/tests/usersync_test.php
@@ -100,7 +100,7 @@ class local_o365_usersync_testcase extends \advanced_testcase {
             'userPrincipalName' => 'testuser'.$i.'@example.onmicrosoft.com',
             'mail' => 'testuser'.$i.'@example.onmicrosoft.com',
             'surname' => 'User'.$i,
-            'preferredLanguage' => ($i == 3) ? 'de-DE' : 'en-US',
+            'preferredLanguage' => ($i == 3) ? 'sa-IN' : 'en-US',
         ];
     }
 


### PR DESCRIPTION
Changed language for testuser3 to a language that Moodle does not support, so there is no chance of its pack being installed.