### PR TITLE
Fix for issue #115: Create sharing link instead of regular link for OneDrive files

### DIFF
--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -914,4 +914,16 @@ class unified extends \local_o365\rest\o365api {
         }
         return $lastsize;
     }
+
+    /**
+     * Create readonly link for onedrive file.
+     * @param $fileid onedrive file id.
+     * @return string Return readonly file url.
+     */
+    public function create_link($fileid) {
+        $params = array('type' => 'view', 'scope' => 'organization');
+        $apiresponse = $this->apicall('post', "/me/drive/items/$fileid/createLink", json_encode($params));
+        $response = $this->process_apicall_response($apiresponse);
+        return $response['link']['webUrl'];
+    }
 }

--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -920,7 +920,7 @@ class unified extends \local_o365\rest\o365api {
      * @param $fileid onedrive file id.
      * @return string Return readonly file url.
      */
-    public function create_link($fileid) {
+    public function get_sharing_link ($fileid) {
         $params = array('type' => 'view', 'scope' => 'organization');
         $apiresponse = $this->apicall('post', "/me/drive/items/$fileid/createLink", json_encode($params));
         $response = $this->process_apicall_response($apiresponse);

--- a/repository/office365/lib.php
+++ b/repository/office365/lib.php
@@ -1009,7 +1009,9 @@ class repository_office365 extends \repository {
                     } else {
                         $sourceclient = $this->get_onedrive_apiclient();
                         $filemetadata = $sourceclient->get_file_metadata($fileid);
-                        $reference['url'] = $filemetadata['webUrl'].'?web=1';
+                        if (isset($filemetadata['webUrl'])) {
+                            $reference['url'] = $filemetadata['webUrl'].'?web=1';
+                        }
                     }
                 } else if ($filesource === 'onedrivegroup') {
                     if ($this->unifiedconfigured !== true) {
@@ -1029,7 +1031,9 @@ class repository_office365 extends \repository {
                     $sourceclient->set_site($parentsiteuri);
                     $reference['parentsiteuri'] = $parentsiteuri;
                     $filemetadata = $sourceclient->get_file_metadata($fileid);
-                    $reference['url'] = $filemetadata['webUrl'].'?web=1';
+                    if (isset($filemetadata['webUrl'])) {
+                        $reference['url'] = $filemetadata['webUrl'].'?web=1';
+                    }
                 }
 
             } catch (\Exception $e) {

--- a/repository/office365/lib.php
+++ b/repository/office365/lib.php
@@ -1005,18 +1005,20 @@ class repository_office365 extends \repository {
                 if ($filesource === 'onedrive') {
                     if ($this->unifiedconfigured === true) {
                         $sourceclient = $this->get_unified_apiclient();
+                        $reference['url'] = $sourceclient->get_sharing_link($fileid);
                     } else {
                         $sourceclient = $this->get_onedrive_apiclient();
+                        $filemetadata = $sourceclient->get_file_metadata($fileid);
+                        $reference['url'] = $filemetadata['webUrl'].'?web=1';
                     }
-                    $filemetadata = $sourceclient->get_file_metadata($fileid);
                 } else if ($filesource === 'onedrivegroup') {
                     if ($this->unifiedconfigured !== true) {
                         \local_o365\utils::debug('Tried to access a onedrive group file while the graph api is disabled.', $caller);
                         throw new \moodle_exception('errorwhiledownload', 'repository_office365');
                     }
                     $sourceclient = $this->get_unified_apiclient();
-                    $filemetadata = $sourceclient->get_group_file_metadata($sourceunpacked['groupid'], $fileid);
                     $reference['groupid'] = $sourceunpacked['groupid'];
+                    $reference['url'] = $sourceclient->get_sharing_link($fileid);
                 } else if ($filesource === 'sharepoint') {
                     $sourceclient = $this->get_sharepoint_apiclient();
                     if (isset($sourceunpacked['parentsiteuri'])) {
@@ -1027,14 +1029,9 @@ class repository_office365 extends \repository {
                     $sourceclient->set_site($parentsiteuri);
                     $reference['parentsiteuri'] = $parentsiteuri;
                     $filemetadata = $sourceclient->get_file_metadata($fileid);
-                }
-
-                if ($this->unifiedconfigured === true) {
-                    $sourceclient = $this->get_unified_apiclient();
-                    $reference['url'] = $sourceclient->create_link($fileid);
-                } else {
                     $reference['url'] = $filemetadata['webUrl'].'?web=1';
                 }
+
             } catch (\Exception $e) {
                 $errmsg = 'There was a problem making the API call.';
                 $debugdata = [

--- a/repository/office365/lib.php
+++ b/repository/office365/lib.php
@@ -1029,7 +1029,10 @@ class repository_office365 extends \repository {
                     $filemetadata = $sourceclient->get_file_metadata($fileid);
                 }
 
-                if (isset($filemetadata['webUrl'])) {
+                if ($this->unifiedconfigured === true) {
+                    $sourceclient = $this->get_unified_apiclient();
+                    $reference['url'] = $sourceclient->create_link($fileid);
+                } else {
                     $reference['url'] = $filemetadata['webUrl'].'?web=1';
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
Creates sharing link when sharing files from OneDrive. Note that the ability to create sharable link is only available in the unified API. So this is only done when unified API is being used.