### PR TITLE
Return sharing link when creating a shotrcut/alias to a file attachme…

### DIFF
--- a/repository/office365/lib.php
+++ b/repository/office365/lib.php
@@ -1173,6 +1173,9 @@ class repository_office365 extends \repository {
         if (empty($reference['source']) || !in_array($reference['source'], ['onedrive', 'sharepoint'])) {
             return false;
         }
+        if (($reference['source'] === 'onedrive') && ($this->unifiedconfigured === true)) {
+            return false;
+        }
         if (!empty($forcedownload)) {
             return false;
         }
@@ -1218,6 +1221,7 @@ class repository_office365 extends \repository {
                     die();
                 }
                 $fileinfo = $sourceclient->get_file_metadata($reference['id']);
+                $fileurl = (isset($fileinfo['webUrl'])) ? $fileinfo['webUrl'] : '';
                 break;
 
             case 'onedrive':
@@ -1227,12 +1231,12 @@ class repository_office365 extends \repository {
                     send_file_not_found();
                     die();
                 }
-                $fileinfo = $sourceclient->get_file_metadata($reference['id']);
+                $fileurl = (isset($reference['url'])) ? $reference['url'] : '';
                 break;
 
             case 'onedrivegroup':
                 $sourceclient = $this->get_unified_apiclient();
-                $fileinfo = $sourceclient->get_group_file_metadata($reference['groupid'], $reference['id']);
+                $fileurl = (isset($reference['url'])) ? $reference['url'] : '';
                 break;
 
             default:
@@ -1250,12 +1254,6 @@ class repository_office365 extends \repository {
                 die();
             }
             if (!empty($sourceclient)) {
-                if (isset($fileinfo['webUrl'])) {
-                    $fileurl = $fileinfo['webUrl'];
-                } else {
-                    $fileurl = (isset($reference['url'])) ? $reference['url'] : '';
-                }
-
                 if (empty($fileurl)) {
                     $errstr = 'Embed was requested, but could not get file info to complete request.';
                     \local_o365\utils::debug($errstr, 'send_file', ['reference' => $reference, 'fileinfo' => $fileinfo]);
@@ -1281,7 +1279,7 @@ class repository_office365 extends \repository {
             }
         }
 
-        redirect($fileinfo['webUrl']);
+        redirect($fileurl);
     }
 
     /**


### PR DESCRIPTION
…nt to Office files. Note that sharing link is only available for unified api on Onedrive. For other cases, we  create the same shortcut / alias as before.