### PR TITLE
Use proper country and default Moodle language when syncing users with AzureAD

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -354,7 +354,7 @@ class main {
 
         // Locate country code.
         if (isset($aaddata['country'])) {
-            $countries = get_string_manager()->get_list_of_countries();
+            $countries = get_string_manager()->get_list_of_countries(true, 'en');
             foreach ($countries as $code => $name) {
                 if ($aaddata['country'] == $name) {
                     $aaddata['country'] = $code;
@@ -369,7 +369,6 @@ class main {
         $newuser = (object)[
             'auth' => 'oidc',
             'username' => trim(\core_text::strtolower($aaddata['userPrincipalName'])),
-            'lang' => 'en',
             'confirmed' => 1,
             'timecreated' => time(),
             'mnethostid' => $CFG->mnet_localhost_id,


### PR DESCRIPTION
The Azure AD API returns country names in English, so when looking up country code by name, we should specify that we need English list of countries as opposed to that in the default language.

This also removes the hardcoded `'lang' => 'en'` element from the array passed when creating the user. This means that the default Moodle language will be assigned to the user, which I think is the right thing to do when the there is no better info available.