### PR TITLE
Fix syncing when User Creation Restriction is a huge o365 group

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -314,10 +314,10 @@ class main {
                     \local_o365\utils::debug('Could not find group (1)', 'check_usercreationrestriction', $group);
                     return false;
                 }
-                $members = $apiclient->get_group_members($group['id']);
-                foreach ($members['value'] as $member) {
-                    if ($member['id'] === $aaddata['id']) {
-                        return true;
+                $usersgroups = $apiclient->get_users_groups($group['id'],$aaddata['id']);
+                foreach($usersgroups['value'] as $usergroup) {
+                    if ($group['id'] === $usergroup) {
+                       return true;
                     }
                 }
                 return false;

--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -413,6 +413,21 @@ class unified extends \local_o365\rest\o365api {
     }
 
     /**
+     * Get a list of all groups a user is member of
+     *
+     * @param string $groupobjectid The object ID of the group
+     * @param string $userobjecttid The user ID
+     * @return array Array of groups user is member of
+     */
+    public function get_users_groups($groupobjectid,$userobjectid) {
+        $endpoint = 'users/'.$userobjectid.'/getMemberGroups';
+        $postdata = '{ "securityEnabledOnly": false }';
+        $response = $this->apicall('post', $endpoint, $postdata);
+        $expectedparams = ['value' => null];
+        return $this->process_apicall_response($response, $expectedparams);
+    }
+
+    /**
      * Get a list of group members.
      *
      * @param string $groupobjectid The object ID of the group.


### PR DESCRIPTION
The call to get_group_members in user sync is not paged, so if the group is big, not all users will be returned, and there for not synced.

A new function has been created in unified.php that will return
all groups a user is member of.

That function is then used in userssync/main.php during sync to
check if a users should be added to moodle or not when a o365
group is selected as a 'User Creation Restriction'