### PR TITLE
Updated User Sync to Call graph API to check groups user is in

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -349,7 +349,7 @@ class main {
             if ($aaddata[$restriction['remotefield']] === $restriction['value']) {
                 return true;
             }
-        }        
+        }
         return false;
     }
 

--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -412,9 +412,9 @@ class unified extends \local_o365\rest\o365api {
         return $response;
     }
 
-        /**
-    * Gets a list of groups for a member
-    *
+     /**
+     * Gets a list of groups for a user
+     *
      * @param string $userobjectid The object ID of the user.
      * @return array Array of returned groups.
      */

--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -412,6 +412,19 @@ class unified extends \local_o365\rest\o365api {
         return $response;
     }
 
+        /**
+    * Gets a list of groups for a member
+    *
+     * @param string $userobjectid The object ID of the user.
+     * @return array Array of returned groups.
+     */
+     public function get_users_groups($userobjectid) {
+        $endpoint = '/users/'.$userobjectid.'/memberOf';
+        $response = $this->apicall('get', $endpoint);
+        $expectedparams = ['value' => null];
+        return $this->process_apicall_response($response, $expectedparams);
+    }
+
     /**
      * Get a list of group members.
      *


### PR DESCRIPTION
When an AD group contains a large amount of users then the results are split over multiple pages. The plugin currently only looks at the first page of results meaning that a user that meets the creation criteria may not be created. The change is to call the graph API to get all of the groups that a user belongs to and check those.