### PR TITLE
Fix #256 Unit test failures when deleting/disconnecting users.

### DIFF
--- a/local/o365/db/events.php
+++ b/local/o365/db/events.php
@@ -121,7 +121,7 @@ $observers = [
         'eventname'   => '\auth_oidc\event\user_disconnected',
         'callback'    => '\local_o365\observers::handle_oidc_user_disconnected',
         'priority'    => 200,
-        'internal'    => false,
+        'internal'    => true,
     ],
     [
         'eventname'   => '\auth_oidc\event\user_loggedin',
@@ -195,6 +195,6 @@ $observers = [
         'eventname'   => '\core\event\user_deleted',
         'callback'    => '\local_o365\observers::handle_user_deleted',
         'priority'    => 200,
-        'internal'    => false,
+        'internal'    => true,
     ],
 ];


### PR DESCRIPTION
This fixes the unit tests. I think it's probably safe to run disconnect/delete actions inside the transaction.