### PR TITLE
Fix obtaining application info

### DIFF
--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -1113,7 +1113,7 @@ class unified extends \local_o365\rest\o365api {
      */
     public function get_application_info() {
         $oidcconfig = get_config('auth_oidc');
-        $endpoint = '/applications/?$filter=id%20eq%20\''.$oidcconfig->clientid.'\'';
+        $endpoint = '/applications/?$filter=appId%20eq%20\''.$oidcconfig->clientid.'\'';
         $response = $this->betaapicall('get', $endpoint);
         $expectedparams = ['value' => null];
         return $this->process_apicall_response($response, $expectedparams);


### PR DESCRIPTION
When you pull application info, the application you are searching for has to be searched for by its appId rather than objectId since objectId != clientId.