### PR TITLE
The url parameter $skiptoken= can not be empty, this will not add it …

### DIFF
--- a/local/o365/classes/rest/azuread.php
+++ b/local/o365/classes/rest/azuread.php
@@ -376,10 +376,7 @@ class azuread extends \local_o365\rest\o365api {
         if ($params === 'default') {
             $params = ['mail', 'city', 'country', 'department', 'givenName', 'surname', 'preferredLanguage', 'userPrincipalName'];
         }
-        if (empty($skiptoken) || !is_string($skiptoken)) {
-            $skiptoken = '';
-        }
-        if (!empty($params) && is_array($params)) {
+        if (!empty($skiptoken) && is_string($skiptoken) && !empty($params) && is_array($params)) {
             $endpoint .= '?$skiptoken='.$skiptoken;
         }
         $response = $this->apicall('get', $endpoint);


### PR DESCRIPTION
The url parameter $skiptoken can not be empty. This fix will not add it if the php variable $skiptoken is empty.

Fixes https://github.com/Microsoft/o365-moodle/issues/264