### PR TITLE
Hide O365 groups from Address List and disable Welcome message.

### DIFF
--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -281,6 +281,7 @@ class unified extends \local_o365\rest\o365api {
             'securityEnabled' => false,
             'mailNickname' => $mailnickname,
             'visibility' => 'Private',
+            'resourceBehaviorOptions' => [ 'HideGroupInOutlook', 'WelcomeEmailDisabled' ],
         ];
 
         if (!empty($extra) && is_array($extra)) {


### PR DESCRIPTION
Sorry, I'm not a developer and haven't used github to submit patches to other projects before.
[Since early 2018](https://www.microsoft.com/en-us/microsoft-365/roadmap?filters=&searchterms=26955) O365 groups created through Teams are hidden from the Outlook Address List by default. Would it be possible to add this functionality to O365 Groups/Teams created by this plugin?

Could an option also be added to disable the email members receive when they are added to a group? We don't find it helpful for students or faculty to be alerted half a dozen times when the groups are generated at the start of the semester.

Here is a pull request showing a simple change for how to achieve both. I'm not able to find official documentation about the "resourceBehaviorOptions" property, but here are some examples of it being used with the Graph API.
[https://techcommunity.microsoft.com/t5/Office-365-Groups/Setting-Unified-Group-properties-via-API/td-p/88101](https://techcommunity.microsoft.com/t5/Office-365-Groups/Setting-Unified-Group-properties-via-API/td-p/88101)
[https://stackoverflow.com/questions/53039373/missing-ad-resourceprovisioningoptions-for-teams-office-365-ad-groups](https://stackoverflow.com/questions/53039373/missing-ad-resourceprovisioningoptions-for-teams-office-365-ad-groups)

