### PR TITLE
Add the ability to lock profile fields like moodle does

### DIFF
--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -30,25 +30,39 @@ class base {
     /** @var \auth_oidc\httpclientinterface An HTTP client to use. */
     protected $httpclient;
 
+   public $optionalconfig;
+
     public function __construct() {
         $default = [
             'opname' => get_string('pluginname', 'auth_oidc')
         ];
         $storedconfig = (array)get_config('auth_oidc');
+
+        $overrideconfig = get_config('local_o365', 'fieldmap');
+        $overrideconfig = (!empty($overrideconfig)) ? @unserialize($overrideconfig) : [];
+
+        if (empty($overrideconfig) || !is_array($overrideconfig)) {
+            $overrideconfig = [];
+        }
+
+        foreach($overrideconfig as $overrides) {
+            $override = explode('/', $overrides);
+            $key = $override[1];
+            $value = $override[3];
+            $optionalconfig['field_lock_' . $key] = $value;
+        }
+
         $forcedconfig = [
             'field_updatelocal_idnumber' => 'oncreate',
             'field_lock_idnumber' => 'locked',
             'field_updatelocal_lang' => 'oncreate',
             'field_lock_lang' => 'locked',
             'field_updatelocal_firstname' => 'onlogin',
-            'field_lock_firstname' => 'unlocked',
             'field_updatelocal_lastname' => 'onlogin',
-            'field_lock_lastname' => 'unlocked',
             'field_updatelocal_email' => 'onlogin',
-            'field_lock_email' => 'unlocked',
         ];
 
-        $this->config = (object)array_merge($default, $storedconfig, $forcedconfig);
+        $this->config = (object)array_merge($default, $storedconfig, $forcedconfig, $optionalconfig);
     }
 
     /**

--- a/local/o365/classes/adminsetting/usersyncfieldmap.php
+++ b/local/o365/classes/adminsetting/usersyncfieldmap.php
@@ -44,8 +44,14 @@ class usersyncfieldmap extends fieldmap {
      * @param array $localfields Array of local fields (ignored + overridden in this child class)
      * @param array $syncbehav Array of sync behaviours. (ignored + overridden in this child class)
      */
-    public function __construct($name, $visiblename, $description, $defaultsetting, $remotefields = [], $localfields = [], $syncbehav = []) {
+    public function __construct($name, $visiblename, $description, $defaultsetting, $remotefields = [], $localfields = [], $syncbehav = [], $lockoptions = []) {
         global $DB;
+
+        $lockoptions = [
+            'unlocked' => get_string('unlocked', 'auth'),
+            'unlockedifempty' => get_string('unlockedifempty', 'auth'),
+            'locked'          => get_string('locked', 'auth'),
+        ];
 
         $syncbehav = [
             'oncreate' => get_string('update_oncreate', 'auth'),
@@ -90,6 +96,6 @@ class usersyncfieldmap extends fieldmap {
             $localfields['profile_field_'.$field->shortname] = $field->name;
         }
 
-        return parent::__construct($name, $visiblename, $description, $defaultsetting, $remotefields, $localfields, $syncbehav);
+        return parent::__construct($name, $visiblename, $description, $defaultsetting, $remotefields, $localfields, $syncbehav, $lockoptions);
     }
 }

--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -336,10 +336,10 @@ class main {
 
         foreach ($fieldmaps as $fieldmap) {
             $fieldmap = explode('/', $fieldmap);
-            if (count($fieldmap) !== 3) {
+            if (count($fieldmap) !== 4) {
                 continue;
             }
-            list($remotefield, $localfield, $behavior) = $fieldmap;
+            list($remotefield, $localfield, $behavior, $locking) = $fieldmap;
             if ($behavior !== 'on'.$eventtype && $behavior !== 'always') {
                 // Field mapping doesn't apply to this event type.
                 continue;

--- a/local/o365/lang/en/local_o365.php
+++ b/local/o365/lang/en/local_o365.php
@@ -309,6 +309,7 @@ $string['settings_fieldmap_addmapping'] = 'Add Mapping';
 $string['settings_fieldmap_details'] = 'Configure mapping between user fields in Office 365 and Moodle.';
 $string['settings_fieldmap_header_behavior'] = 'Updates';
 $string['settings_fieldmap_header_local'] = 'Moodle Field';
+$string['settings_fieldmap_header_locking'] = 'Locking';
 $string['settings_fieldmap_header_remote'] = 'Active Directory Field';
 $string['settings_fieldmap_field_city'] = 'City';
 $string['settings_fieldmap_field_companyName'] = 'Company Name';


### PR DESCRIPTION
This adds the ability to lock profile fields in sync settings.

I added the standard "unlocked, Unlocked if empty, and Locked" options that are present in most other authentication methods.