### PR TITLE
Prevent guest user from being connected upon login

### DIFF
--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -235,7 +235,7 @@ class authcode extends \auth_oidc\loginflow\base {
 
         // Check if OIDC user is already migrated.
         $tokenrec = $DB->get_record('auth_oidc_token', ['oidcuniqid' => $oidcuniqid]);
-        if (isloggedin() === true && (empty($tokenrec) || (isset($USER->auth) && $USER->auth !== 'oidc'))) {
+        if (isloggedin() && !isguestuser() && (empty($tokenrec) || (isset($USER->auth) && $USER->auth !== 'oidc'))) {
 
             // If user is already logged in and trying to link Office 365 account or use it for OIDC.
             // Check if that Office 365 account already exists in moodle.


### PR DESCRIPTION
If a user has not been automatically synced from O365, then they are automatically synced upon login. However, this connects the user with the guest user in Moodle, in a nearly irrevocable way. This fixes this issue.

I'm not really sure how to add a regression test for this - it seems like auth_oidc doesn't really have a ton of unit tests? At least I can't find any that call `handleredirect`.