### PR TITLE
Limit Teams Description to Less than 1024 Characters

### DIFF
--- a/local/o365/classes/feature/usergroups/coursegroups.php
+++ b/local/o365/classes/feature/usergroups/coursegroups.php
@@ -304,6 +304,9 @@ class coursegroups {
         }
 
         $description = $course->summary;
+        if (strlen($description) > 1024) {
+            $description = substr($description, 0, 1020) . ' ...';
+        }
 
         $extra = null;
 


### PR DESCRIPTION
When creating a team, the description cannot be longer that 1024 character. The create_group function correctly limits the description, but the create_team function does not.