### PR TITLE
Users with numeric usernames are not syncing

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -720,7 +720,7 @@ class main {
         $params = array_merge(['user'], $upnparams, $usernameparams, [$CFG->mnet_localhost_id, '0']);
         $linkedexistingusers = $DB->get_records_sql($sql, $params);
 
-        $existingusers = array_merge($existingusers, $linkedexistingusers);
+        $existingusers = $existingusers + $linkedexistingusers;
 
         foreach ($aadusers as $user) {
             $this->mtrace(' ');


### PR DESCRIPTION
As noted in https://www.php.net/manual/en/function.array-merge.php#92602
The array_merge function does not preserve numeric key values.  If you need to preserve the numeric keys, then using + will do that.