### PR TITLE
auth_oidc: fix setcreds function

### DIFF
--- a/auth/oidc/classes/oidcclient.php
+++ b/auth/oidc/classes/oidcclient.php
@@ -56,10 +56,11 @@ class oidcclient {
      *
      * @param string $id The registered client ID.
      * @param string $secret The registered client secret.
-     * @param string $scope The requested OID scope.
      * @param string $redirecturi The registered client redirect URI.
+     * @param string $resource The API URL
+     * @param string $scope The requested OID scope.
      */
-    public function setcreds($id, $secret, $redirecturi, $resource, $scope) {
+    public function setcreds($id, $secret, $redirecturi, $resource = null, $scope = null) {
         $this->clientid = $id;
         $this->clientsecret = $secret;
         $this->redirecturi = $redirecturi;


### PR DESCRIPTION
https://github.com/microsoft/moodle-auth_oidc/pull/43 added the $scope parameter which wasn't optional, this breaks unit tests as seen below:
```
Moodle 3.9.1+ (Build: 20200814), b21f40b26d12dcfd13017c21827b5353370588a5
Php: 7.2.31.1.18.04.1.1, pgsql: 10.14 (Ubuntu 10.14-0ubuntu0.18.04.1), OS: Linux 5.4.0-45-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

...........E...........                                           23 / 23 (100%)

Time: 8.87 seconds, Memory: 565.00 MB

There was 1 error:

1) auth_oidc_oidcclient_testcase::test_creds_getters_and_setters
ArgumentCountError: Too few arguments to function auth_oidc\oidcclient::setcreds(), 4 passed in /<REMOVED>/auth/oidc/tests/oidcclient_test.php on line 58 and exactly 5 expected

/<REMOVED>/auth/oidc/classes/oidcclient.php:62
/<REMOVED>/auth/oidc/tests/oidcclient_test.php:58
/<REMOVED>/lib/phpunit/classes/advanced_testcase.php:80

To re-run:
 vendor/bin/phpunit "auth_oidc_oidcclient_testcase" auth/oidc/tests/oidcclient_test.php

ERRORS!
Tests: 23, Assertions: 65, Errors: 1.
```
On these lines https://github.com/microsoft/moodle-auth_oidc/blob/master/classes/oidcclient.php#L66,L71 $resource and $scope are optional because of the empty checks, so I made them optional in the function definition. Unit tests now pass with this patch.