### PR TITLE
Retroactively add users to teams during OIDC connect

### DIFF
--- a/local/o365/classes/observers.php
+++ b/local/o365/classes/observers.php
@@ -169,6 +169,37 @@ class observers {
                 } else {
                     \local_o365\utils::debug('no oidcuniqid received', 'handle_oidc_user_connected', $eventdata);
                 }
+
+                # Enrol user to all courses he was enrolled prior to connecting
+                # Do not attempt to enrol the user if user groups are not enabled
+                if (\local_o365\feature\usergroups\utils::is_enabled() !== true)
+                    return true;
+
+                try {
+                    $apiclient = \local_o365\utils::get_api();
+                    $courses = enrol_get_users_courses($userid, true);
+
+                    $roleteacher = $DB->get_record('role', array('shortname' => 'editingteacher'));
+                    $rolenoneditingteacher = $DB->get_record('role', array('shortname' => 'teacher'));
+
+                    foreach ($courses as $courseid => $course) {
+                        if (\local_o365\feature\usergroups\utils::course_is_group_enabled($courseid) !== true)
+                            continue;
+
+                        $courseuserroles = enrol_get_course_users_roles($courseid);
+                        $userroles = $courseuserroles[$userid];
+
+                        if (array_key_exists($roleteacher->id, $userroles) || array_key_exists($rolenoneditingteacher->id, $userroles)) {
+                            $response = $apiclient->add_owner_to_course_group($courseid, $userid);
+                        } else {
+                            $response = $apiclient->add_user_to_course_group($courseid, $userid);
+                        }
+                    }
+                } catch (\Exception $e) {
+                    \local_o365\utils::debug('Exception: '.$e->getMessage(), $caller, $e);
+                    return true;
+                }
+
                 return true;
             } catch (\Exception $e) {
                 \local_o365\utils::debug($e->getMessage(), 'handle_oidc_user_connected', $e);


### PR DESCRIPTION
The current code listens to events like enrolling / unenrolling / changing user enrolment information if the changes are made after the user connects to OIDC.

However, consider the following scenario (each item in the list happens before the next item):
- a user is created using another authentication method, or manually by the administrator
- the user is enrolled into courses `A`, `B` and `C`
- the user is synced with the active directory
- the user is enrolled into course `D`

Because the enrolment into course `D` happened after synchronizing the account the AD, the database contains an o365 local object for the user, so a `\local_o365\obj\o365user` instance can be created. This means that the handlers for user enrolment like `handle_user_enrolment_created` can add the user to the team. In contrast, since the enrolments for courses `A`, `B` and `C` were created before the user was synchronized, an object did not exist, so the user was not added to the team.

The changes check what courses the user was enrolled into before connecting to OIDC and adding them to the teams according to their enrolment status, so at least the changes are visible once the user connects their account.