### PR TITLE
local/o365: Fix observers owner capability checks

### DIFF
--- a/local/o365/classes/observers.php
+++ b/local/o365/classes/observers.php
@@ -691,7 +691,7 @@ class observers {
                     } else {
                         $apiclient = \local_o365\utils::get_api();
                         $context = \context_course::instance($courseid);
-                        $roles = get_roles_with_capability('local/o365:teamowner', 'CAP_ALLOW', $context);
+                        $roles = get_roles_with_capability('local/o365:teamowner', CAP_ALLOW, $context);
                         if (!empty($roles)) {
                             $roles = array_keys($roles);
                             if (in_array($roleid, $roles)) {
@@ -745,7 +745,7 @@ class observers {
                             $caller);
                     } else {
                         $context = \context_course::instance($courseid);
-                        $roles = get_roles_with_capability('local/o365:teamowner', 'CAP_ALLOW', $context);
+                        $roles = get_roles_with_capability('local/o365:teamowner', CAP_ALLOW, $context);
                         if (!empty($roles)) {
                             $roles = array_keys($roles);
                             if (in_array($roleid, $roles)) {


### PR DESCRIPTION
A recent commit changed the way team owners are identified by adding the `local/o365:teamowner` capability.
However, when fetching the roles with the capabilities in `local/o365/classes/observers.php`, `CAP_ALLOW` is used as a string instead of a macro.