### PR TITLE
Remove Graph API calls to '/me/' endpoints

### DIFF
--- a/local/o365/classes/feature/calsync/task/importfromoutlook.php
+++ b/local/o365/classes/feature/calsync/task/importfromoutlook.php
@@ -64,7 +64,9 @@ class importfromoutlook extends \core\task\scheduled_task {
         foreach ($calsubs as $i => $calsub) {
             try {
                 mtrace('Syncing events for user #'.$calsub->user_id);
-                $events = $calsync->get_events($calsub->user_id, $calsub->o365calid, $laststarttime);
+
+                $o365upn = \local_o365\utils::get_o365_upn($calsub->user_id);
+                $events = $calsync->get_events($calsub->user_id, $calsub->o365calid, $laststarttime, $o365upn);
                 if (!empty($events) && is_array($events) && isset($events['value']) && is_array($events['value'])) {
                     if (!empty($events['value'])) {
                         foreach ($events['value'] as $i => $event) {

--- a/local/o365/classes/utils.php
+++ b/local/o365/classes/utils.php
@@ -197,6 +197,17 @@ class utils {
     }
 
     /**
+     * Get the object ID of the connected Microsoft 365 account.
+     *
+     * @param $userid
+     * @return null
+     */
+    public static function get_o365_userid($userid) {
+        $o365user = \local_o365\obj\o365user::instance_from_muserid($userid);
+        return (!empty($o365user)) ? $o365user->objectid : null;
+    }
+
+    /**
      * Determine if a user is connected to Microsoft 365.
      *
      * @param int $userid The user's ID.

--- a/local/onenote/README.md
+++ b/local/onenote/README.md
@@ -28,7 +28,6 @@ None. This plugin depends upon the Microsoft Account local plugin to be configur
 This is a singleton class that provides simple wrappers for various authentication and the OneNote online REST API. Some of the functionality provided includes:
 - render_signin_widget: Returns the HTML for displaying the signin widget for Microsoft OneNote.
 - get_items_list: Used for drilling down the hierarchy of OneNote notebooks, sections, and pages.
-- get_item_name: Returns the name of a notebook, section, or page.
 - download_page: Downloads the contents of a OneNote page, including the HTML and any images; saves them in a folder and creates a .zip file out of it.
 - render_action_button: Returns the HTML for displaying action buttons that allow students to view or work on OneNote assignments and teachers to provide feedback on them.
 - get_page: Gets (or creates) the student submission page or teacher feedback page in OneNote for the given student assignment. Performs all actions such as determining if a page already exists and returning that; or determining if this is the first time a student is accessing the assignment and creating the page from the assignment title / prompt etc; or determining if a downloaded zipped page already exists and thawing the OneNote page from that.

--- a/local/onenote/classes/api/base.php
+++ b/local/onenote/classes/api/base.php
@@ -341,30 +341,6 @@ abstract class base {
     }
 
     /**
-     * Returns the name of the OneNote item (notebook or section) given its id.
-     *
-     * @param string $itemid the id of the OneNote notebook or section
-     * @return string|bool item name or false in case of error
-     */
-    public function get_item_name($itemid) {
-        if (empty($itemid)) {
-            throw new \coding_exception('Empty item_id passed to get_item_name');
-        }
-
-        $response = json_decode($this->apicall('get', '/notebooks/'.$itemid));
-        if (empty($response) || isset($response->error)) {
-            $response = json_decode($this->apicall('get', '/sections/'.$itemid));
-            if (empty($response) || isset($response->error)) {
-                $debugdata = ['response' => $response, 'itemid' => $itemid];
-                \local_onenote\utils::debug('could not find itemid', 'onenote\api\base::get_item_name', $debugdata);
-                return false;
-            }
-        }
-
-        return $response->name.".zip";
-    }
-
-    /**
      * Returns a list of OneNote item(s) at the given path (notebooks or sections or pages).
      *
      * @param string $path The path containing notebook id / section id / page id.
@@ -498,7 +474,6 @@ abstract class base {
      * Ensure that notebook and section data in the logged-in user's OneNote account are in sync with our database tables.
      */
     public function sync_notebook_data() {
-        global $DB;
         $notebookname = get_string('notebookname', 'local_onenote');
         $courses = enrol_get_my_courses(); // Get the current user enrolled courses.
         $notebooksarray = [];

--- a/local/onenote/classes/api/o365.php
+++ b/local/onenote/classes/api/o365.php
@@ -44,7 +44,8 @@ class o365 extends base {
         try {
             if (\local_o365\rest\unified::is_configured() === true) {
                 $apiclient = \local_o365\rest\unified::instance_for_user($USER->id);
-                $apimethod = '/me/onenote'.$apimethod;
+                $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+                $apimethod = '/users/' . $o365userid . '/onenote' .$apimethod;
             } else {
                 $apiclient = \local_o365\rest\onenote::instance_for_user($USER->id);
             }

--- a/local/onenote/tests/onenoteapi_test.php
+++ b/local/onenote/tests/onenoteapi_test.php
@@ -147,31 +147,6 @@ class local_onenote_onenoteapi_testcase extends advanced_testcase {
     }
 
     /**
-     * Test for getitemname api
-     */
-    public function test_getitemaname() {
-        return true; // Need to update test to not require config data.
-        $this->set_test_config();
-        $this->set_user(0);
-
-        $itemlist = $this->onenoteapi->get_items_list();
-
-        foreach ($itemlist as $item) {
-            if ($item['title'] == 'Moodle Notebook') {
-                $this->assertEquals($item['title'].'.zip', $this->onenoteapi->get_item_name($item['id']),
-                    'Unable to get notebook name');
-
-                $subitems = $this->onenoteapi->get_items_list($item['path']);
-                foreach ($subitems as $subitem) {
-                    $this->assertEquals($subitem['title'].'.zip', $this->onenoteapi->get_item_name($subitem['id']),
-                        'Unable to get section name');
-                    break;
-                }
-            }
-        }
-    }
-
-    /**
      * Test for onenote action button
      */
     public function test_renderactionbutton() {

--- a/mod/assign/feedback/onenote/locallib.php
+++ b/mod/assign/feedback/onenote/locallib.php
@@ -203,7 +203,7 @@ class assign_feedback_onenote extends assign_feedback_plugin {
      * @return bool True on successful save, false on error.
      */
     public function save(stdClass $grade, stdClass $data) {
-        global $DB, $COURSE;
+        global $DB, $COURSE, $USER;
 
         // Get the OneNote page id corresponding to the teacher's feedback for this submission.
         $record = $DB->get_record('local_onenote_assign_pages', ['assign_id' => $grade->assignment, 'user_id' => $grade->userid]);
@@ -222,8 +222,9 @@ class assign_feedback_onenote extends assign_feedback_plugin {
         $tempfolder = $onenoteapi->create_temp_folder();
         $tempfile = join(DIRECTORY_SEPARATOR, array(rtrim($tempfolder, DIRECTORY_SEPARATOR), uniqid('asg_'))) . '.zip';
 
+        $o365userid = \local_o365\utils::get_o365_userid($USER->id);
         // Create zip file containing onenote page and related files.
-        $downloadinfo = $onenoteapi->download_page($record->feedback_teacher_page_id, $tempfile);
+        $downloadinfo = $onenoteapi->download_page($record->feedback_teacher_page_id, $tempfile, $o365userid);
 
         if ($downloadinfo) {
 

--- a/mod/assign/submission/onenote/locallib.php
+++ b/mod/assign/submission/onenote/locallib.php
@@ -220,7 +220,8 @@ class assign_submission_onenote extends assign_submission_plugin {
         $tempfile = join(DIRECTORY_SEPARATOR, array(rtrim($tempfolder, DIRECTORY_SEPARATOR), uniqid('asg_'))) . '.zip';
 
         // Create zip file containing onenote page and related files.
-        $downloadinfo = $onenoteapi->download_page($record->submission_student_page_id, $tempfile);
+        $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+        $downloadinfo = $onenoteapi->download_page($record->submission_student_page_id, $tempfile, $o365userid);
 
         if (!$downloadinfo) {
             if ($onenoteapi->is_logged_in()) {

--- a/repository/office365/lib.php
+++ b/repository/office365/lib.php
@@ -415,7 +415,8 @@ class repository_office365 extends \repository {
             if ($this->unifiedconfigured === true) {
                 $apiclient = $this->get_unified_apiclient();
                 $parentid = (!empty($filepath)) ? substr($filepath, 1) : '';
-                $result = $apiclient->create_file($parentid, $filename, $content, 'application/octet-stream');
+                $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+                $result = $apiclient->create_file($parentid, $filename, $content, 'application/octet-stream', $o365userid);
             } else {
                 $apiclient = $this->get_onedrive_apiclient();
                 $result = $apiclient->create_file($filepath, $filename, $content);
@@ -849,7 +850,10 @@ class repository_office365 extends \repository {
      * @return array List of $list array and $path array.
      */
     protected function get_listing_my_unified($path = '') {
+        global $USER;
+
         $path = (empty($path)) ? '/' : $path;
+        $caller = '/repository_office365::get_listing_my_unified';
 
         $list = [];
 
@@ -864,7 +868,9 @@ class repository_office365 extends \repository {
             $realpath = substr($path, 0, -strlen('/upload/'));
         } else {
             try {
-                $contents = $unified->get_files($realpath);
+                $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+                $contents = $unified->get_files($realpath, $o365userid);
+
                 $list = $this->contents_api_response_to_list($contents, $realpath, 'unified');
             } catch (\Exception $e) {
                 $errmsg = 'Exception when retrieving personal onedrive files for folder';
@@ -878,7 +884,8 @@ class repository_office365 extends \repository {
         }
 
         if ($realpath !== '/') {
-            $metadata = $unified->get_file_metadata($realpath);
+            $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+            $metadata = $unified->get_file_metadata($realpath, $o365userid);
             if (!empty($metadata['parentReference']) && !empty($metadata['parentReference']['path'])) {
                 $parentrefpath = substr($metadata['parentReference']['path'], (strpos($metadata['parentReference']['path'], ':') + 1));
                 $cache = \cache::make('repository_office365', 'unifiedfolderids');
@@ -953,12 +960,15 @@ class repository_office365 extends \repository {
      * @return array List of $list array and $path array.
      */
     protected function get_listing_trending_unified($path = '') {
+        global $USER;
+
         $path = (empty($path)) ? '/' : $path;
-        $list = [];
+        $caller = '\repository_office365::get_listing_trending_unified';
         $unified = $this->get_unified_apiclient();
         $realpath = $path;
         try {
-            $contents = $unified->get_trending_files($realpath);
+            $o365upn = \local_o365\utils::get_o365_upn($USER->id);
+            $contents = $unified->get_trending_files($realpath, $o365upn);
             $list = $this->contents_api_response_to_list($contents, $realpath, 'trendingaround', null, false);
         } catch (\Exception $e) {
             $errmsg = 'Exception when retrieving personal trending files';
@@ -1194,6 +1204,8 @@ class repository_office365 extends \repository {
      *   url: URL to the source (from parameters)
      */
     public function get_file($reference, $filename = '') {
+        global $USER;
+
         $caller = '\repository_office365::get_file';
         $reference = $this->unpack_reference($reference);
 
@@ -1207,7 +1219,8 @@ class repository_office365 extends \repository {
                 \local_o365\utils::debug('Could not construct onedrive api.', $caller);
                 throw new \moodle_exception('errorwhiledownload', 'repository_office365');
             }
-            $file = $sourceclient->get_file_by_id($reference['id']);
+            $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+            $file = $sourceclient->get_file_by_id($reference['id'], $o365userid);
         } else if ($reference['source'] === 'onedrivegroup') {
             if ($this->unifiedconfigured === true) {
                 $sourceclient = $this->get_unified_apiclient();
@@ -1292,6 +1305,8 @@ class repository_office365 extends \repository {
      * @return string file reference, ready to be stored
      */
     public function get_file_reference($source) {
+        global $USER;
+
         $caller = '\repository_office365::get_file_reference';
         $sourceunpacked = $this->unpack_reference($source);
         if (isset($sourceunpacked['source']) && isset($sourceunpacked['id'])) {
@@ -1315,7 +1330,8 @@ class repository_office365 extends \repository {
                 if ($filesource === 'onedrive') {
                     if ($this->unifiedconfigured === true) {
                         $sourceclient = $this->get_unified_apiclient();
-                        $reference['url'] = $sourceclient->get_sharing_link($fileid);
+                        $o365userid = \local_o365\utils::get_o365_userid($USER->id);
+                        $reference['url'] = $sourceclient->get_sharing_link($fileid, $o365userid);
                     } else {
                         $sourceclient = $this->get_onedrive_apiclient();
                         $filemetadata = $sourceclient->get_file_metadata($fileid);


### PR DESCRIPTION
Making Graph API calls to '/me/' paths would require certain delegated permissions even if the integration is configured to use application access