### PR TITLE
Fix bug on check user group

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -630,7 +630,7 @@ class main {
                 }
                 $usersgroups = $apiclient->get_user_groups($aaddata['id']);
                 foreach ($usersgroups as $usergroup) {
-                    if ($group['id'] === $usergroup) {
+                    if ($group['id'] === $usergroup['id']) {
                         return true;
                     }
                 }


### PR DESCRIPTION
The $usergroup variable is a object returned from array $usergroups (from function get_user_groups). So, the comparison operand was incorrect, because it was not using the correct reference to the index. This was causing the sync return message "Cannot create user because they do not meet..." when the user is a member of a group filtered by the user