### PR TITLE
fix typo in $deletetokenurl

### DIFF
--- a/auth/oidc/lib.php
+++ b/auth/oidc/lib.php
@@ -166,7 +166,7 @@ function auth_oidc_get_tokens_with_mismatched_usernames() {
         $item->matchingstatus = get_string('mismatched', 'auth_oidc');
         $item->details = get_string('mismatched_details', 'auth_oidc',
             ['tokenusername' => $record->tokenusername, 'moodleusername' => $record->musername]);
-        $deletetokenurl = new moodle_url('/auth/oidc/cleanupiodctokens.php', ['id' => $record->id]);
+        $deletetokenurl = new moodle_url('/auth/oidc/cleanupoidctokens.php', ['id' => $record->id]);
         $item->action = html_writer::link($deletetokenurl, get_string('delete_token_and_reference', 'auth_oidc'));
 
         $mismatchedtokens[$record->id] = $item;


### PR DESCRIPTION
One of our customer noticed that he received a 404 when he tried to cleanup an oidc token.

I ended up noticing that the url is wrong.

(Error can be reproduced only when clicking "Delete token and reference")