### PR TITLE
Avoid PHP warning on login

### DIFF
--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -122,11 +122,13 @@ class base {
                 }
             }
             $userfromadditionaltenant = false;
-            foreach ($additionaltenants as $additionaltenant) {
-                $additionaltenant = '@' . $additionaltenant;
-                if (stripos($username, $additionaltenant) !== false) {
-                    $userfromadditionaltenant = true;
-                    break;
+            if(is_countable($additionaltenants) && !empty($additionaltenants)) {
+                foreach ($additionaltenants as $additionaltenant) {
+                    $additionaltenant = '@' . $additionaltenant;
+                    if (stripos($username, $additionaltenant) !== false) {
+                        $userfromadditionaltenant = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Warning: Invalid argument supplied for foreach() in auth/oidc/classes/loginflow/base.php on line 125