### PR TITLE
fix sync_users looking only for usernames when matching against moodle mail

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -987,10 +987,14 @@ class main {
             return true;
         }
 
-        $select = 'SELECT LOWER(u.username) AS username,';
-        if (isset($aadsync['emailsync'])) {
-            $select .= ' LOWER(u.email) AS email,';
-        }
+        /* In order to find existing user accounts using isset($existingusers[$aadupn]) we have to index the array
+         * by email address if we match AAD UPNs against Moodle email addresses!
+         * TODO: We may run into problems if we have multiple accounts with the same mail address!
+         *       See setting `allowaccountssameemail`.
+         */
+        $select = isset($aadsync['emailsync']) ?
+            "SELECT LOWER(u.email) AS email, LOWER(u.username) AS username," :
+            "SELECT LOWER(u.username) AS username";
 
         $sql = "$select
                        u.id as muserid,


### PR DESCRIPTION
resolves #2034 for Moodle 3.9

Further down the file ([lines 1084 and following](https://github.com/microsoft/o365-moodle/compare/MOODLE_39_STABLE...edaktik:2034-user-matching-mail-m39?expand=1#diff-f30a979a96ac6856b4fbc18c0a3cd585e6c58db8c2e0210704a1be6dbf061fe8L1084)) existing users are only checked via array key of $existingusers, which was indexed only by usernames, no matter what had to be compared against. This resulted in not found users if the Moodle username was not related to AAD UPN (or all variants like lowercase, without tenant, etc.).