### PR TITLE
Performance issue in Sync users with Azure AD schedule task in PostgreSQL

### DIFF
--- a/local/o365/lib.php
+++ b/local/o365/lib.php
@@ -450,15 +450,10 @@ function local_o365_set_default_user_sync_suspension_feature_schedule() {
  */
 function local_o365_get_duplicate_emails() {
     global $DB;
-
-    $sql = 'SELECT DISTINCT LOWER(a.email)
-              FROM {user} a
-              JOIN {user} b ON a.email LIKE b.email
-             WHERE a.id < b.id 
-               AND a.deleted = 0
-               AND b.deleted = 0
-               AND a.suspended = 0
-               AND b.suspended = 0';
+    
+    $sql = 'SELECT LOWER(email) FROM {user}
+        WHERE deleted = 0 and suspended = 0
+        GROUP BY LOWER(email) HAVING COUNT(*) > 1';
 
     $records = $DB->get_records_sql($sql);
     return array_keys($records);


### PR DESCRIPTION
Hi,

We have seen that local_o365 has a performance issue in 'Sync users with Azure AD' schedule task in PostgreSQL. The issue includes the task taking minutes to complete. 

Our site environment included:
- Moodle 4.1 
- local_o365 version 2022041910
- Database PostgreSQL

To replicate the issue, go to schedule task logs and see the duration of task usersync of local_o365

The test results after the fix was deployed on our test site
- Before the fix -> duration was 2 mins 53.15 secs (highest point) 
- After the fix  -> duration was 3.47 secs (highest point)

Note: To be able to see the result, you need to have enough test data.

Cheers,
Sumaiya