### PR TITLE
fix(auth_oidc): fallback to sub claim if iod not present

### DIFF
--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -228,7 +228,7 @@ class base {
                     if (empty($objectid)) {
                         $objectid = $token->claim('sub');
                     }
-                    if (!$objectid) {
+                    if (!empty($objectid)) {
                         $userdata['objectId'] = $objectid;
                     }
                 }


### PR DESCRIPTION
The issue is explained in #2295 
I decided not to add the fallback in https://github.com/microsoft/o365-moodle/blob/254fce25e057ad964f7bb3954b3086bf9cf689e2/auth/oidc/classes/loginflow/base.php#L225-L230 as it is a specific case for local_365 which is supposed to support the `oid` claim.
In my case, we are using a third-party provider which doesn't have `oid` by default