### PR TITLE
fix(MIME type): update MIME type for CSV files

### DIFF
--- a/local/o365/classes/page/acp.php
+++ b/local/o365/classes/page/acp.php
@@ -430,7 +430,7 @@ class acp extends base {
                 $finfo = new finfo();
                 $type = $finfo->file($datafile, FILEINFO_MIME);
                 $type = explode(';', $type);
-                if (strtolower($type[0]) === 'text/plain') {
+                if (strtolower($type[0]) === 'text/plain' || strtolower($type[0]) === 'text/csv' || strtolower($type[0]) === 'application/csv') {
                     try {
                         $fh = fopen($datafile, 'r');
                         if (!empty($fh)) {


### PR DESCRIPTION
closes #2282

Tested on Windows 11 Pro Version	10.0.22621 Build 22621

## Tested browsers
Edge: Version 114.0.1823.43 (Official build) (64-bit)

Firefox: Version 114.0.1823.43 (Official build) (64-bit)

## Description
This pull request fixes an issue that occurs when uploading CSV files using the plugin on different browsers. Some browsers send a different MIME type when uploading the file, causing errors in the file upload. This pull request updates the code in the local/o365/classes/page/acp.php file, line 433, to allow users to upload CSV files correctly from any browser.