### PR TITLE
Fix `Fatal error` because of missing argument in local_o365\oauth2\systemtoken::instance

### DIFF
--- a/local/o365/classes/oauth2/systemtoken.php
+++ b/local/o365/classes/oauth2/systemtoken.php
@@ -39,10 +39,12 @@ class systemtoken extends \local_o365\oauth2\token {
      * @param string $tokenresource The new resource.
      * @param \local_o365\oauth2\clientdata $clientdata Client information.
      * @param \local_o365\httpclientinterface $httpclient An HTTP client.
+     * @param bool $forcecreate
      *
      * @return \local_o365\oauth2\token|bool A constructed token for the new resource, or false if failure.
      */
-    public static function instance($userid, $tokenresource, \local_o365\oauth2\clientdata $clientdata, $httpclient) {
+    public static function instance($userid, $tokenresource, \local_o365\oauth2\clientdata $clientdata, $httpclient,
+                                    $forcecreate = false) {
     }
 
     /**


### PR DESCRIPTION
We are using the o365 plugin version 4.1.2 with Moodle 4.1. We've recently upgraded our Moodle setup to PHP 8.1. Since then we noticed that some course pages failed to load completely. PHP is logging the following error message: 

> PHP Fatal error:  Declaration of local_o365\oauth2\systemtoken::instance($userid, $tokenresource, local_o365\oauth2\clientdata $clientdata, $httpclient) must be compatible with local_o365\oauth2\token::instance($userid, $tokenresource, local_o365\oauth2\clientdata $clientdata , $httpclient, $forcecreate = false) in /www/local/o365/classes/oauth2/systemtoken.php on line 45

When debugging the issue we noticed that the following line appears to be missing the `$forcecreate` parameter:

https://github.com/microsoft/o365-moodle/blob/4fb684192b3290a56a7bf1d49181e86c901e3d2d/local/o365/classes/oauth2/systemtoken.php#L45

which the token class contains:

https://github.com/microsoft/o365-moodle/blob/4fb684192b3290a56a7bf1d49181e86c901e3d2d/local/o365/classes/oauth2/token.php#L156-L157

By adding the argument to the method we were able to fix that issue. As this is a pretty small change I thought I would already prepare a PR :slightly_smiling_face: 