### PR TITLE
V20230628 m402 ein patch

### DIFF
--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -564,7 +564,13 @@ class authcode extends base {
 
         $usernamechanged = false;
         if ($oidcusername && $tokenrec && $oidcusername !== $tokenrec->oidcusername) {
-            $usernamechanged = true;
+            // PATCH - refs #2685838
+            // The tokenrec->oidcusername will never match the idtoken->upn,
+            // so never try to update it (leave $usernamechanged == false).
+            if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+            } else {
+                $usernamechanged = true;
+            }
         }
 
         $existingmatching = null;

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -380,7 +380,16 @@ class authcode extends base {
             if ($USER->id && $DB->record_exists('auth_oidc_token', ['userid' => $USER->id])) {
                 $DB->set_field('auth_oidc_token', 'sid', $sid, ['userid' => $USER->id]);
             }
-            redirect(core_login_get_return_url());
+
+            // PATCH - refs #1700609
+            // Redirects users to other site to cache the sites cookie in the browser session.
+            // URL encode the redirect URL because it may contain '&' or other restricted characters.
+            if (!empty(getenv('O365_CUSTOM_REDIRECT_URL'))) {
+                header("Location: ".getenv('O365_CUSTOM_REDIRECT_URL').urlencode(core_login_get_return_url()));
+                die();
+            } else {
+                redirect(core_login_get_return_url());
+            }
         }
     }
 

--- a/local/o365/classes/oauth2/systemtoken.php
+++ b/local/o365/classes/oauth2/systemtoken.php
@@ -39,10 +39,12 @@ class systemtoken extends \local_o365\oauth2\token {
      * @param string $tokenresource The new resource.
      * @param \local_o365\oauth2\clientdata $clientdata Client information.
      * @param \local_o365\httpclientinterface $httpclient An HTTP client.
+     * @param bool $forcecreate
      *
      * @return \local_o365\oauth2\token|bool A constructed token for the new resource, or false if failure.
      */
-    public static function instance($userid, $tokenresource, \local_o365\oauth2\clientdata $clientdata, $httpclient) {
+    public static function instance($userid, $tokenresource, \local_o365\oauth2\clientdata $clientdata, $httpclient,
+                                    $forcecreate = false) {
     }
 
     /**


### PR DESCRIPTION
If a username (UPN) were changed in Active Directory, the default behavior would be to update the username in Moodle, but when creating a username based on the ``employeeNumber`` instead of the UPN from AD, we know for a certainty the username is correct and should not be updated.

refs: 2685838