### PR TITLE
local_o365: Remove require_once($CFG->libdir.'/externallib.php')

### DIFF
--- a/local/o365/classes/webservices/create_onenoteassignment.php
+++ b/local/o365/classes/webservices/create_onenoteassignment.php
@@ -28,11 +28,13 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Create assignment API class.
@@ -44,14 +46,14 @@ class create_onenoteassignment extends external_api {
      * @return external_function_parameters The parameters object for this webservice method.
      */
     public static function assignment_create_parameters() {
-        return new \external_function_parameters([
-            'data' => new \external_single_structure([
-                'name' => new \external_value(PARAM_TEXT, 'name'),
-                'course' => new \external_value(PARAM_INT, 'course id'),
-                'intro' => new \external_value(PARAM_TEXT, 'intro', VALUE_DEFAULT, ''),
-                'section' => new \external_value(PARAM_INT, 'section', VALUE_DEFAULT, 0),
-                'visible' => new \external_value(PARAM_BOOL, 'visible', VALUE_DEFAULT, false),
-                'duedate' => new \external_value(PARAM_INT, 'duedate', VALUE_DEFAULT, 0),
+        return new external_function_parameters([
+            'data' => new external_single_structure([
+                'name' => new external_value(PARAM_TEXT, 'name'),
+                'course' => new external_value(PARAM_INT, 'course id'),
+                'intro' => new external_value(PARAM_TEXT, 'intro', VALUE_DEFAULT, ''),
+                'section' => new external_value(PARAM_INT, 'section', VALUE_DEFAULT, 0),
+                'visible' => new external_value(PARAM_BOOL, 'visible', VALUE_DEFAULT, false),
+                'duedate' => new external_value(PARAM_INT, 'duedate', VALUE_DEFAULT, 0),
             ])
         ]);
     }

--- a/local/o365/classes/webservices/delete_onenoteassignment.php
+++ b/local/o365/classes/webservices/delete_onenoteassignment.php
@@ -28,11 +28,13 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Delete assignment API class.
@@ -44,10 +46,10 @@ class delete_onenoteassignment extends external_api {
      * @return external_function_parameters The parameters object for this webservice method.
      */
     public static function assignment_delete_parameters() {
-        return new \external_function_parameters([
-            'data' => new \external_single_structure([
-                'coursemodule' => new \external_value(PARAM_INT, 'course module id'),
-                'course' => new \external_value(PARAM_INT, 'course id'),
+        return new external_function_parameters([
+            'data' => new external_single_structure([
+                'coursemodule' => new external_value(PARAM_INT, 'course module id'),
+                'course' => new external_value(PARAM_INT, 'course id'),
             ])
         ]);
     }
@@ -82,8 +84,8 @@ class delete_onenoteassignment extends external_api {
      */
     public static function assignment_delete_returns() {
         $params = [
-            'result' => new \external_value(PARAM_BOOL, 'success/failure'),
+            'result' => new external_value(PARAM_BOOL, 'success/failure'),
         ];
-        return new \external_single_structure($params);
+        return new external_single_structure($params);
     }
 }

--- a/local/o365/classes/webservices/read_assignments.php
+++ b/local/o365/classes/webservices/read_assignments.php
@@ -28,11 +28,16 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
+use core_external\external_format_value;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
+use core_external\external_warnings;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 require_once($CFG->dirroot.'/user/externallib.php');
 require_once($CFG->dirroot.'/mod/assign/locallib.php');
 
@@ -47,27 +52,27 @@ class read_assignments extends external_api {
      * @return external_function_parameters
      */
     public static function assignments_read_parameters() {
-        return new \external_function_parameters([
-            'courseids' => new \external_multiple_structure(
-                new \external_value(PARAM_INT, 'course id, empty for retrieving all the courses where the user is enroled in'),
+        return new external_function_parameters([
+            'courseids' => new external_multiple_structure(
+                new external_value(PARAM_INT, 'course id, empty for retrieving all the courses where the user is enroled in'),
                 '0 or more course ids',
                 VALUE_DEFAULT,
                 []
             ),
-            'assignmentids' => new \external_multiple_structure(
-                new \external_value(PARAM_INT,
+            'assignmentids' => new external_multiple_structure(
+                new external_value(PARAM_INT,
                     'assignment id, empty for retrieving all assignments for courses the user is enroled in'),
                 '0 or more assignment ids',
                 VALUE_DEFAULT,
                 []
             ),
-            'capabilities'  => new \external_multiple_structure(
-                new \external_value(PARAM_CAPABILITY, 'capability'),
+            'capabilities'  => new external_multiple_structure(
+                new external_value(PARAM_CAPABILITY, 'capability'),
                 'list of capabilities used to filter courses',
                 VALUE_DEFAULT,
                 []
             ),
-            'includenotenrolledcourses' => new \external_value(
+            'includenotenrolledcourses' => new external_value(
                 PARAM_BOOL,
                 'whether to return courses that the user can see even if is not enroled in. This requires the parameter ' .
                 'courseids to not be empty.',
@@ -307,43 +312,43 @@ class read_assignments extends external_api {
      * @since Moodle 2.4
      */
     private static function get_assignments_assignment_structure() {
-        return new \external_single_structure(
+        return new external_single_structure(
             array(
-                'id' => new \external_value(PARAM_INT, 'assignment id'),
-                'cmid' => new \external_value(PARAM_INT, 'course module id'),
-                'course' => new \external_value(PARAM_INT, 'course id'),
-                'name' => new \external_value(PARAM_TEXT, 'assignment name'),
-                'nosubmissions' => new \external_value(PARAM_INT, 'no submissions'),
-                'submissiondrafts' => new \external_value(PARAM_INT, 'submissions drafts'),
-                'sendnotifications' => new \external_value(PARAM_INT, 'send notifications'),
-                'sendlatenotifications' => new \external_value(PARAM_INT, 'send notifications'),
-                'sendstudentnotifications' => new \external_value(PARAM_INT, 'send student notifications (default)'),
-                'duedate' => new \external_value(PARAM_INT, 'assignment due date'),
-                'allowsubmissionsfromdate' => new \external_value(PARAM_INT, 'allow submissions from date'),
-                'grade' => new \external_value(PARAM_INT, 'grade type'),
-                'timemodified' => new \external_value(PARAM_INT, 'last time assignment was modified'),
-                'completionsubmit' => new \external_value(PARAM_INT, 'if enabled, set activity as complete following submission'),
-                'cutoffdate' => new \external_value(PARAM_INT, 'date after which submission is not accepted without an extension'),
-                'teamsubmission' => new \external_value(PARAM_INT, 'if enabled, students submit as a team'),
-                'requireallteammemberssubmit' => new \external_value(PARAM_INT, 'if enabled, all team members must submit'),
-                'teamsubmissiongroupingid' => new \external_value(PARAM_INT, 'the grouping id for the team submission groups'),
-                'blindmarking' => new \external_value(PARAM_INT, 'if enabled, hide identities until reveal identities actioned'),
-                'revealidentities' => new \external_value(PARAM_INT, 'show identities for a blind marking assignment'),
-                'attemptreopenmethod' => new \external_value(PARAM_TEXT, 'method used to control opening new attempts'),
-                'maxattempts' => new \external_value(PARAM_INT, 'maximum number of attempts allowed'),
-                'markingworkflow' => new \external_value(PARAM_INT, 'enable marking workflow'),
-                'markingallocation' => new \external_value(PARAM_INT, 'enable marking allocation'),
-                'requiresubmissionstatement' => new \external_value(PARAM_INT, 'student must accept submission statement'),
-                'configs' => new \external_multiple_structure(self::get_assignments_config_structure(), 'configuration settings'),
-                'intro' => new \external_value(PARAM_RAW,
+                'id' => new external_value(PARAM_INT, 'assignment id'),
+                'cmid' => new external_value(PARAM_INT, 'course module id'),
+                'course' => new external_value(PARAM_INT, 'course id'),
+                'name' => new external_value(PARAM_TEXT, 'assignment name'),
+                'nosubmissions' => new external_value(PARAM_INT, 'no submissions'),
+                'submissiondrafts' => new external_value(PARAM_INT, 'submissions drafts'),
+                'sendnotifications' => new external_value(PARAM_INT, 'send notifications'),
+                'sendlatenotifications' => new external_value(PARAM_INT, 'send notifications'),
+                'sendstudentnotifications' => new external_value(PARAM_INT, 'send student notifications (default)'),
+                'duedate' => new external_value(PARAM_INT, 'assignment due date'),
+                'allowsubmissionsfromdate' => new external_value(PARAM_INT, 'allow submissions from date'),
+                'grade' => new external_value(PARAM_INT, 'grade type'),
+                'timemodified' => new external_value(PARAM_INT, 'last time assignment was modified'),
+                'completionsubmit' => new external_value(PARAM_INT, 'if enabled, set activity as complete following submission'),
+                'cutoffdate' => new external_value(PARAM_INT, 'date after which submission is not accepted without an extension'),
+                'teamsubmission' => new external_value(PARAM_INT, 'if enabled, students submit as a team'),
+                'requireallteammemberssubmit' => new external_value(PARAM_INT, 'if enabled, all team members must submit'),
+                'teamsubmissiongroupingid' => new external_value(PARAM_INT, 'the grouping id for the team submission groups'),
+                'blindmarking' => new external_value(PARAM_INT, 'if enabled, hide identities until reveal identities actioned'),
+                'revealidentities' => new external_value(PARAM_INT, 'show identities for a blind marking assignment'),
+                'attemptreopenmethod' => new external_value(PARAM_TEXT, 'method used to control opening new attempts'),
+                'maxattempts' => new external_value(PARAM_INT, 'maximum number of attempts allowed'),
+                'markingworkflow' => new external_value(PARAM_INT, 'enable marking workflow'),
+                'markingallocation' => new external_value(PARAM_INT, 'enable marking allocation'),
+                'requiresubmissionstatement' => new external_value(PARAM_INT, 'student must accept submission statement'),
+                'configs' => new external_multiple_structure(self::get_assignments_config_structure(), 'configuration settings'),
+                'intro' => new external_value(PARAM_RAW,
                     'assignment intro, not allways returned because it deppends on the activity configuration', VALUE_OPTIONAL),
-                'introformat' => new \external_format_value('intro', VALUE_OPTIONAL),
-                'introattachments' => new \external_multiple_structure(
-                    new \external_single_structure(
+                'introformat' => new external_format_value('intro', VALUE_OPTIONAL),
+                'introattachments' => new external_multiple_structure(
+                    new external_single_structure(
                         array (
-                            'filename' => new \external_value(PARAM_FILE, 'file name'),
-                            'mimetype' => new \external_value(PARAM_RAW, 'mime type'),
-                            'fileurl'  => new \external_value(PARAM_URL, 'file download url')
+                            'filename' => new external_value(PARAM_FILE, 'file name'),
+                            'mimetype' => new external_value(PARAM_RAW, 'mime type'),
+                            'fileurl'  => new external_value(PARAM_URL, 'file download url')
                         )
                     ), 'intro attachments files', VALUE_OPTIONAL
                 )
@@ -357,14 +362,14 @@ class read_assignments extends external_api {
      * @since Moodle 2.4
      */
     private static function get_assignments_config_structure() {
-        return new \external_single_structure(
+        return new external_single_structure(
             array(
-                'id' => new \external_value(PARAM_INT, 'assign_plugin_config id'),
-                'assignment' => new \external_value(PARAM_INT, 'assignment id'),
-                'plugin' => new \external_value(PARAM_TEXT, 'plugin'),
-                'subtype' => new \external_value(PARAM_TEXT, 'subtype'),
-                'name' => new \external_value(PARAM_TEXT, 'name'),
-                'value' => new \external_value(PARAM_TEXT, 'value')
+                'id' => new external_value(PARAM_INT, 'assign_plugin_config id'),
+                'assignment' => new external_value(PARAM_INT, 'assignment id'),
+                'plugin' => new external_value(PARAM_TEXT, 'plugin'),
+                'subtype' => new external_value(PARAM_TEXT, 'subtype'),
+                'name' => new external_value(PARAM_TEXT, 'name'),
+                'value' => new external_value(PARAM_TEXT, 'value')
             ), 'assignment configuration object'
         );
     }
@@ -376,13 +381,13 @@ class read_assignments extends external_api {
      * @since Moodle 2.4
      */
     private static function get_assignments_course_structure() {
-        return new \external_single_structure(
+        return new external_single_structure(
             array(
-                'id' => new \external_value(PARAM_INT, 'course id'),
-                'fullname' => new \external_value(PARAM_TEXT, 'course full name'),
-                'shortname' => new \external_value(PARAM_TEXT, 'course short name'),
-                'timemodified' => new \external_value(PARAM_INT, 'last time modified'),
-                'assignments' => new \external_multiple_structure(self::get_assignments_assignment_structure(), 'assignment info')
+                'id' => new external_value(PARAM_INT, 'course id'),
+                'fullname' => new external_value(PARAM_TEXT, 'course full name'),
+                'shortname' => new external_value(PARAM_TEXT, 'course short name'),
+                'timemodified' => new external_value(PARAM_INT, 'last time modified'),
+                'assignments' => new external_multiple_structure(self::get_assignments_assignment_structure(), 'assignment info')
               ), 'course information object'
         );
     }
@@ -394,10 +399,10 @@ class read_assignments extends external_api {
      * @since Moodle 2.4
      */
     public static function assignments_read_returns() {
-        return new \external_single_structure(
+        return new external_single_structure(
             array(
-                'courses' => new \external_multiple_structure(self::get_assignments_course_structure(), 'list of courses'),
-                'warnings'  => new \external_warnings('item can be \'course\' (errorcode 1 or 2) or \'module\' (errorcode 1)',
+                'courses' => new external_multiple_structure(self::get_assignments_course_structure(), 'list of courses'),
+                'warnings'  => new external_warnings('item can be \'course\' (errorcode 1 or 2) or \'module\' (errorcode 1)',
                     'When item is a course then itemid is a course id. When the item is a module then itemid is a module id',
                     'errorcode can be 1 (no access rights) or 2 (not enrolled or no permissions)')
             )

--- a/local/o365/classes/webservices/read_bot_message.php
+++ b/local/o365/classes/webservices/read_bot_message.php
@@ -28,8 +28,11 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
-
-require_once($CFG->libdir.'/externallib.php');
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
+use core_external\external_warnings;
 
 /**
  * Get help card for user.
@@ -42,14 +45,14 @@ class read_bot_message extends external_api {
      * @return external_function_parameters
      */
     public static function bot_message_read_parameters() {
-        return new \external_function_parameters([
-            'intent' => new \external_value(
+        return new external_function_parameters([
+            'intent' => new external_value(
                 PARAM_TEXT,
                 'Bot intent',
                 VALUE_DEFAULT,
                 'en'
             ),
-            'entities' => new \external_value(
+            'entities' => new external_value(
                 PARAM_RAW,
                 'Intent entities',
                 VALUE_DEFAULT,
@@ -84,13 +87,13 @@ class read_bot_message extends external_api {
      * @return external_single_structure
      */
     private static function get_cards_structure() {
-        return new \external_single_structure(
+        return new external_single_structure(
             array(
-                'title' => new \external_value(PARAM_TEXT, 'list item title'),
-                'subtitle' => new \external_value(PARAM_RAW, 'list item subtitle'),
-                'icon' => new \external_value(PARAM_URL, 'list item icon url'),
-                'action' => new \external_value(PARAM_TEXT, 'list item action url or text'),
-                'actionType' => new \external_value(PARAM_TEXT, 'list item action type'),
+                'title' => new external_value(PARAM_TEXT, 'list item title'),
+                'subtitle' => new external_value(PARAM_RAW, 'list item subtitle'),
+                'icon' => new external_value(PARAM_URL, 'list item icon url'),
+                'action' => new external_value(PARAM_TEXT, 'list item action url or text'),
+                'actionType' => new external_value(PARAM_TEXT, 'list item action type'),
             ), 'listcard list item data'
         );
     }
@@ -101,17 +104,17 @@ class read_bot_message extends external_api {
      * @return external_single_structure
      */
     public static function bot_message_read_returns() {
-        return new \external_single_structure(
+        return new external_single_structure(
             array(
-                'message' => new \external_value(PARAM_TEXT, 'message to be returned', VALUE_DEFAULT, ''),
-                'listTitle' => new \external_value(PARAM_TEXT, 'title that is showed below the message and above
+                'message' => new external_value(PARAM_TEXT, 'message to be returned', VALUE_DEFAULT, ''),
+                'listTitle' => new external_value(PARAM_TEXT, 'title that is showed below the message and above
                     the list cards', VALUE_DEFAULT, ''),
-                'listItems' => new \external_multiple_structure(self::get_cards_structure(), 'list of cards to beshowed
+                'listItems' => new external_multiple_structure(self::get_cards_structure(), 'list of cards to beshowed
                     with message', VALUE_DEFAULT, []),
-                'warnings'  => new \external_warnings('warning messages that occured when getting data',
+                'warnings'  => new external_warnings('warning messages that occured when getting data',
                     'Item id is mod or user id and if not possible to define 0 by default',
                     ''),
-                'language' => new \external_value(PARAM_TEXT, 'message language', VALUE_DEFAULT, 'en'),
+                'language' => new external_value(PARAM_TEXT, 'message language', VALUE_DEFAULT, 'en'),
             )
         );
     }

--- a/local/o365/classes/webservices/read_courseusers.php
+++ b/local/o365/classes/webservices/read_courseusers.php
@@ -28,11 +28,14 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Get a list of students in a course by course id.
@@ -41,16 +44,16 @@ class read_courseusers extends external_api {
     /**
      * Return description of method parameters.
      *
-     * @return \external_function_parameters
+     * @return external_function_parameters
      */
     public static function courseusers_read_parameters() {
-        return new \external_function_parameters(
+        return new external_function_parameters(
             [
-                'courseid' => new \external_value(PARAM_INT, 'course id'),
-                'limitfrom' => new \external_value(PARAM_INT, 'sql limit from', VALUE_DEFAULT, 0),
-                'limitnumber' => new \external_value(PARAM_INT, 'maximum number of returned users', VALUE_DEFAULT, 0),
-                'userids' => new \external_multiple_structure(
-                    new \external_value(PARAM_INT, 'user id, empty to retrieve all users'),
+                'courseid' => new external_value(PARAM_INT, 'course id'),
+                'limitfrom' => new external_value(PARAM_INT, 'sql limit from', VALUE_DEFAULT, 0),
+                'limitnumber' => new external_value(PARAM_INT, 'maximum number of returned users', VALUE_DEFAULT, 0),
+                'userids' => new external_multiple_structure(
+                    new external_value(PARAM_INT, 'user id, empty to retrieve all users'),
                     '0 or more user ids',
                     VALUE_DEFAULT,
                     []
@@ -175,23 +178,23 @@ class read_courseusers extends external_api {
      * @return external_description
      */
     public static function courseusers_read_returns() {
-        return new \external_multiple_structure(
-            new \external_single_structure(
+        return new external_multiple_structure(
+            new external_single_structure(
                 [
-                    'id' => new \external_value(PARAM_INT, 'ID of the user'),
-                    'username' => new \external_value(PARAM_RAW, 'Username policy is defined in Moodle security config',
+                    'id' => new external_value(PARAM_INT, 'ID of the user'),
+                    'username' => new external_value(PARAM_RAW, 'Username policy is defined in Moodle security config',
                         VALUE_OPTIONAL),
-                    'fullname' => new \external_value(PARAM_NOTAGS, 'The fullname of the user'),
-                    'firstname' => new \external_value(PARAM_NOTAGS, 'The first name(s) of the user', VALUE_OPTIONAL),
-                    'lastname' => new \external_value(PARAM_NOTAGS, 'The family name of the user', VALUE_OPTIONAL),
-                    'email' => new \external_value(PARAM_TEXT, 'An email address - allow email as root@localhost', VALUE_OPTIONAL),
-                    'idnumber' => new \external_value(PARAM_RAW, 'An arbitrary ID code number perhaps from the institution',
+                    'fullname' => new external_value(PARAM_NOTAGS, 'The fullname of the user'),
+                    'firstname' => new external_value(PARAM_NOTAGS, 'The first name(s) of the user', VALUE_OPTIONAL),
+                    'lastname' => new external_value(PARAM_NOTAGS, 'The family name of the user', VALUE_OPTIONAL),
+                    'email' => new external_value(PARAM_TEXT, 'An email address - allow email as root@localhost', VALUE_OPTIONAL),
+                    'idnumber' => new external_value(PARAM_RAW, 'An arbitrary ID code number perhaps from the institution',
                         VALUE_OPTIONAL),
-                    'lang' => new \external_value(PARAM_RAW, 'An arbitrary ID code number perhaps from the institution',
+                    'lang' => new external_value(PARAM_RAW, 'An arbitrary ID code number perhaps from the institution',
                         VALUE_OPTIONAL),
-                    'profileimageurlsmall' => new \external_value(PARAM_URL, 'User image profile URL - small version',
+                    'profileimageurlsmall' => new external_value(PARAM_URL, 'User image profile URL - small version',
                         VALUE_OPTIONAL),
-                    'profileimageurl' => new \external_value(PARAM_URL, 'User image profile URL - big version', VALUE_OPTIONAL),
+                    'profileimageurl' => new external_value(PARAM_URL, 'User image profile URL - big version', VALUE_OPTIONAL),
                 ]
             )
         );

--- a/local/o365/classes/webservices/read_onenoteassignment.php
+++ b/local/o365/classes/webservices/read_onenoteassignment.php
@@ -28,11 +28,13 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Read assignment API class.
@@ -44,10 +46,10 @@ class read_onenoteassignment extends external_api {
      * @return external_function_parameters The parameters object for this webservice method.
      */
     public static function assignment_read_parameters() {
-        return new \external_function_parameters([
-            'data' => new \external_single_structure([
-                'coursemodule' => new \external_value(PARAM_INT, 'course module id'),
-                'course' => new \external_value(PARAM_INT, 'course id'),
+        return new external_function_parameters([
+            'data' => new external_single_structure([
+                'coursemodule' => new external_value(PARAM_INT, 'course module id'),
+                'course' => new external_value(PARAM_INT, 'course id'),
             ])
         ]);
     }

--- a/local/o365/classes/webservices/read_teachercourses.php
+++ b/local/o365/classes/webservices/read_teachercourses.php
@@ -28,11 +28,14 @@ namespace local_o365\webservices;
 defined('MOODLE_INTERNAL') || die();
 
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Get a list of courses where the current user is a teacher.
@@ -44,9 +47,9 @@ class read_teachercourses extends external_api {
      * @return external_function_parameters
      */
     public static function teachercourses_read_parameters() {
-        return new \external_function_parameters([
-            'courseids' => new \external_multiple_structure(
-                new \external_value(PARAM_INT, 'course id, empty to retrieve all courses'),
+        return new external_function_parameters([
+            'courseids' => new external_multiple_structure(
+                new external_value(PARAM_INT, 'course id, empty to retrieve all courses'),
                 '0 or more course ids',
                 VALUE_DEFAULT,
                 []
@@ -122,18 +125,18 @@ class read_teachercourses extends external_api {
      * @return external_description
      */
     public static function teachercourses_read_returns() {
-        return new \external_multiple_structure(
-            new \external_single_structure(
+        return new external_multiple_structure(
+            new external_single_structure(
                 [
-                    'id' => new \external_value(PARAM_INT, 'id of course'),
-                    'shortname' => new \external_value(PARAM_RAW, 'short name of course'),
-                    'fullname' => new \external_value(PARAM_RAW, 'long name of course'),
-                    'idnumber' => new \external_value(PARAM_RAW, 'id number of course'),
-                    'visible' => new \external_value(PARAM_INT, '1 means visible, 0 means hidden course'),
-                    'format' => new \external_value(PARAM_PLUGIN, 'course format: weeks, topics, social, site', VALUE_OPTIONAL),
-                    'showgrades' => new \external_value(PARAM_BOOL, 'true if grades are shown, otherwise false', VALUE_OPTIONAL),
-                    'lang' => new \external_value(PARAM_LANG, 'forced course language', VALUE_OPTIONAL),
-                    'enablecompletion' => new \external_value(PARAM_BOOL, 'true if completion is enabled, otherwise false',
+                    'id' => new external_value(PARAM_INT, 'id of course'),
+                    'shortname' => new external_value(PARAM_RAW, 'short name of course'),
+                    'fullname' => new external_value(PARAM_RAW, 'long name of course'),
+                    'idnumber' => new external_value(PARAM_RAW, 'id number of course'),
+                    'visible' => new external_value(PARAM_INT, '1 means visible, 0 means hidden course'),
+                    'format' => new external_value(PARAM_PLUGIN, 'course format: weeks, topics, social, site', VALUE_OPTIONAL),
+                    'showgrades' => new external_value(PARAM_BOOL, 'true if grades are shown, otherwise false', VALUE_OPTIONAL),
+                    'lang' => new external_value(PARAM_LANG, 'forced course language', VALUE_OPTIONAL),
+                    'enablecompletion' => new external_value(PARAM_BOOL, 'true if completion is enabled, otherwise false',
                         VALUE_OPTIONAL),
                 ]
             )

--- a/local/o365/classes/webservices/update_grade.php
+++ b/local/o365/classes/webservices/update_grade.php
@@ -29,11 +29,14 @@ defined('MOODLE_INTERNAL') || die();
 
 use local_o365\webservices\exception as exception;
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 require_once($CFG->dirroot.'/user/externallib.php');
 require_once($CFG->dirroot.'/mod/assign/locallib.php');
 
@@ -71,30 +74,30 @@ class update_grade extends external_api {
                 foreach ($details as $key => $value) {
                     $value->required = VALUE_OPTIONAL;
                     unset($value->content->keys['id']);
-                    $items[$key] = new \external_multiple_structure (new \external_single_structure(
+                    $items[$key] = new external_multiple_structure (new external_single_structure(
                         array(
-                            'criterionid' => new \external_value(PARAM_INT, 'criterion id'),
+                            'criterionid' => new external_value(PARAM_INT, 'criterion id'),
                             'fillings' => $value
                         )
                     ));
                 }
-                $advancedgradingdata[$method] = new \external_single_structure($items, 'items', VALUE_OPTIONAL);
+                $advancedgradingdata[$method] = new external_single_structure($items, 'items', VALUE_OPTIONAL);
             }
         }
 
-        return new \external_function_parameters(
+        return new external_function_parameters(
             array(
-                'assignmentid' => new \external_value(PARAM_INT, 'The assignment id to operate on'),
-                'userid' => new \external_value(PARAM_INT, 'The student id to operate on'),
-                'grade' => new \external_value(PARAM_FLOAT, 'The new grade for this user. Ignored if advanced grading used'),
-                'attemptnumber' => new \external_value(PARAM_INT, 'The attempt number (-1 means latest attempt)'),
-                'addattempt' => new \external_value(PARAM_BOOL, 'Allow another attempt if the attempt reopen method is manual'),
-                'workflowstate' => new \external_value(PARAM_ALPHA, 'The next marking workflow state'),
-                'applytoall' => new \external_value(PARAM_BOOL, 'If true, this grade will be applied ' .
+                'assignmentid' => new external_value(PARAM_INT, 'The assignment id to operate on'),
+                'userid' => new external_value(PARAM_INT, 'The student id to operate on'),
+                'grade' => new external_value(PARAM_FLOAT, 'The new grade for this user. Ignored if advanced grading used'),
+                'attemptnumber' => new external_value(PARAM_INT, 'The attempt number (-1 means latest attempt)'),
+                'addattempt' => new external_value(PARAM_BOOL, 'Allow another attempt if the attempt reopen method is manual'),
+                'workflowstate' => new external_value(PARAM_ALPHA, 'The next marking workflow state'),
+                'applytoall' => new external_value(PARAM_BOOL, 'If true, this grade will be applied ' .
                                                                'to all members ' .
                                                                'of the group (for group assignments).'),
-                'plugindata' => new \external_single_structure($pluginfeedbackparams, 'plugin data', VALUE_DEFAULT, array()),
-                'advancedgradingdata' => new \external_single_structure($advancedgradingdata, 'advanced grading data',
+                'plugindata' => new external_single_structure($pluginfeedbackparams, 'plugin data', VALUE_DEFAULT, array()),
+                'advancedgradingdata' => new external_single_structure($advancedgradingdata, 'advanced grading data',
                                                                        VALUE_DEFAULT, array())
             )
         );
@@ -192,9 +195,9 @@ class update_grade extends external_api {
      * @return external_single_structure Object describing return parameters for this webservice method.
      */
     public static function grade_update_returns() {
-        return new \external_single_structure([
-            'id' => new \external_value(PARAM_INT, 'id of grade'),
-            'itemid' => new \external_value(PARAM_INT, 'id of grade item'),
+        return new external_single_structure([
+            'id' => new external_value(PARAM_INT, 'id of grade'),
+            'itemid' => new external_value(PARAM_INT, 'id of grade item'),
         ]);
     }
 }

--- a/local/o365/classes/webservices/update_onenoteassignment.php
+++ b/local/o365/classes/webservices/update_onenoteassignment.php
@@ -29,11 +29,13 @@ defined('MOODLE_INTERNAL') || die();
 
 use local_o365\webservices\exception as exception;
 use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
-require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Update assignment API class.
@@ -45,14 +47,14 @@ class update_onenoteassignment extends external_api {
      * @return external_function_parameters The parameters object for this webservice method.
      */
     public static function assignment_update_parameters() {
-        return new \external_function_parameters([
-            'data' => new \external_single_structure([
-                'coursemodule' => new \external_value(PARAM_INT, 'course module id'),
-                'course' => new \external_value(PARAM_INT, 'course id'),
-                'name' => new \external_value(PARAM_TEXT, 'name', VALUE_DEFAULT, null),
-                'intro' => new \external_value(PARAM_TEXT, 'intro', VALUE_DEFAULT, null),
-                'section' => new \external_value(PARAM_INT, 'section', VALUE_DEFAULT, null),
-                'visible' => new \external_value(PARAM_BOOL, 'visible', VALUE_DEFAULT, null),
+        return new external_function_parameters([
+            'data' => new external_single_structure([
+                'coursemodule' => new external_value(PARAM_INT, 'course module id'),
+                'course' => new external_value(PARAM_INT, 'course id'),
+                'name' => new external_value(PARAM_TEXT, 'name', VALUE_DEFAULT, null),
+                'intro' => new external_value(PARAM_TEXT, 'intro', VALUE_DEFAULT, null),
+                'section' => new external_value(PARAM_INT, 'section', VALUE_DEFAULT, null),
+                'visible' => new external_value(PARAM_BOOL, 'visible', VALUE_DEFAULT, null),
             ])
         ]);
     }

--- a/local/o365/classes/webservices/utils.php
+++ b/local/o365/classes/webservices/utils.php
@@ -25,6 +25,9 @@
 
 namespace local_o365\webservices;
 
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
 use \local_o365\webservices\exception as exception;
 
 defined('MOODLE_INTERNAL') || die();
@@ -67,23 +70,23 @@ class utils {
     /**
      * Get the external structure schema when returning information about an assignment.
      *
-     * @return \external_single_structure The return data schema.
+     * @return external_single_structure The return data schema.
      */
     public static function get_assignment_return_info_schema() {
         $params = [
-            'data' => new \external_multiple_structure(
-                new \external_single_structure([
-                    'course' => new \external_value(PARAM_INT, 'course id'),
-                    'coursemodule' => new \external_value(PARAM_INT, 'coursemodule id'),
-                    'name' => new \external_value(PARAM_TEXT, 'name'),
-                    'intro' => new \external_value(PARAM_TEXT, 'intro'),
-                    'section' => new \external_value(PARAM_INT, 'section'),
-                    'visible' => new \external_value(PARAM_INT, 'visible'),
-                    'instance' => new \external_value(PARAM_INT, 'instance id'),
+            'data' => new external_multiple_structure(
+                new external_single_structure([
+                    'course' => new external_value(PARAM_INT, 'course id'),
+                    'coursemodule' => new external_value(PARAM_INT, 'coursemodule id'),
+                    'name' => new external_value(PARAM_TEXT, 'name'),
+                    'intro' => new external_value(PARAM_TEXT, 'intro'),
+                    'section' => new external_value(PARAM_INT, 'section'),
+                    'visible' => new external_value(PARAM_INT, 'visible'),
+                    'instance' => new external_value(PARAM_INT, 'instance id'),
                 ])
             ),
         ];
-        return new \external_single_structure($params);
+        return new external_single_structure($params);
     }
 
     /**

--- a/local/o365/tests/webservices_onenoteassignment_test.php
+++ b/local/o365/tests/webservices_onenoteassignment_test.php
@@ -23,11 +23,10 @@
  * @copyright (C) 2014 onwards Microsoft Open Technologies, Inc. (http://msopentech.com/)
  */
 
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+
 defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
-
-require_once($CFG->dirroot.'/lib/externallib.php');
 
 /**
  * Tests \local_o365\webservices\utils
@@ -56,7 +55,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_create_parameters() {
         $schema = \local_o365\webservices\create_onenoteassignment::assignment_create_parameters();
-        $this->assertTrue($schema instanceof \external_function_parameters);
+        $this->assertTrue($schema instanceof external_function_parameters);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -133,7 +132,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_create_returns() {
         $schema = \local_o365\webservices\create_onenoteassignment::assignment_create_returns();
-        $this->assertTrue($schema instanceof \external_single_structure);
+        $this->assertTrue($schema instanceof external_single_structure);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -142,7 +141,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_read_parameters() {
         $schema = \local_o365\webservices\read_onenoteassignment::assignment_read_parameters();
-        $this->assertTrue($schema instanceof \external_function_parameters);
+        $this->assertTrue($schema instanceof external_function_parameters);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -330,7 +329,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_read_returns() {
         $schema = \local_o365\webservices\read_onenoteassignment::assignment_read_returns();
-        $this->assertTrue($schema instanceof \external_single_structure);
+        $this->assertTrue($schema instanceof external_single_structure);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -339,7 +338,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_update_parameters() {
         $schema = \local_o365\webservices\update_onenoteassignment::assignment_update_parameters();
-        $this->assertTrue($schema instanceof \external_function_parameters);
+        $this->assertTrue($schema instanceof external_function_parameters);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -500,7 +499,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_update_returns() {
         $schema = \local_o365\webservices\update_onenoteassignment::assignment_update_returns();
-        $this->assertTrue($schema instanceof \external_single_structure);
+        $this->assertTrue($schema instanceof external_single_structure);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -509,7 +508,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_delete_parameters() {
         $schema = \local_o365\webservices\delete_onenoteassignment::assignment_delete_parameters();
-        $this->assertTrue($schema instanceof \external_function_parameters);
+        $this->assertTrue($schema instanceof external_function_parameters);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 
@@ -570,7 +569,7 @@ class local_o365_webservices_onenoteassignment_testcase extends \advanced_testca
      */
     public function test_assignment_delete_returns() {
         $schema = \local_o365\webservices\delete_onenoteassignment::assignment_delete_returns();
-        $this->assertTrue($schema instanceof \external_single_structure);
+        $this->assertTrue($schema instanceof external_single_structure);
         $this->assertArrayHasKey('result', $schema->keys);
     }
 }

--- a/local/o365/tests/webservices_utils_test.php
+++ b/local/o365/tests/webservices_utils_test.php
@@ -23,11 +23,9 @@
  * @copyright (C) 2014 onwards Microsoft Open Technologies, Inc. (http://msopentech.com/)
  */
 
+use core_external\external_single_structure;
+
 defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
-
-require_once($CFG->dirroot.'/lib/externallib.php');
 
 /**
  * Tests \local_o365\webservices\utils
@@ -422,7 +420,7 @@ class local_o365_webservices_utils_testcase extends \advanced_testcase {
      */
     public function test_get_assignment_return_info_schema() {
         $schema = \local_o365\webservices\utils::get_assignment_return_info_schema();
-        $this->assertTrue($schema instanceof \external_single_structure);
+        $this->assertTrue($schema instanceof external_single_structure);
         $this->assertArrayHasKey('data', $schema->keys);
     }
 


### PR DESCRIPTION
Refactors codebase for local_o365 replacing require_once with use statements. This also resolve the issue around the coding exception which occurs during unit tests: 
```
coding_exception: Coding error detected, it must be fixed by a programmer: When including this file for a unit test, the test must be run in an isolated process. See the PHPUnit @runInSeparateProcess and @runTestsInSeparateProcesses annotations.
```

Resolves #2398.  