### PR TITLE
Implement can_be_manually_set()

### DIFF
--- a/auth/oidc/auth.php
+++ b/auth/oidc/auth.php
@@ -73,6 +73,15 @@ class auth_plugin_oidc extends \auth_plugin_base {
     }
 
     /**
+     * Returns true if plugin can be manually set.
+     *
+     * @return bool
+     */
+    function can_be_manually_set() {
+        return true;
+    }
+
+    /**
      * Returns a list of potential IdPs that this authentication plugin supports. Used to provide links on the login page.
      *
      * @param string $wantsurl The relative url fragment the user wants to get to.


### PR DESCRIPTION
Fixes #2494 

This suppresses user upload warnings and allows oidc to be selected as a default auth method if none are included in the csv.