### PR TITLE
import class auth_oidc\event\action_failed in classes/utils.php

### DIFF
--- a/auth/oidc/classes/utils.php
+++ b/auth/oidc/classes/utils.php
@@ -27,6 +27,7 @@ namespace auth_oidc;
 
 use Exception;
 use moodle_exception;
+use auth_oidc\event\action_failed;
 
 defined('MOODLE_INTERNAL') || die();
 


### PR DESCRIPTION
When debugmode is on the following error has been produced

![authoidc_classnotfound](https://github.com/microsoft/o365-moodle/assets/5802893/0b26feac-6394-4633-871f-d6accceb795d)

Importing the missing class should fix this problem.

Addresses https://github.com/microsoft/o365-moodle/issues/2571