### PR TITLE
Add iconurl icon display on login page

### DIFF
--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -79,6 +79,9 @@ class authcode extends base {
             }
             $idpentry['icon'] = $iconvalue;
         }
+        else{
+            $idpentry['iconurl'] = '';
+        }
         return [$idpentry];
     }
 


### PR DESCRIPTION
@weilai-irl
a mistake was made during the last PR #3123 . You cannot remove the iconurl key, otherwise the error "Warning: Undefined array key "iconurl" in / appearsvar/www/moodle/lib/authlib.php on line 759", because the icon is mandatory in terms of keys.  btw, I want to work on PR for the moodle core to fix this misunderstanding.
