### PR TITLE
AUTH_OIDC_IDP_TYPE_OTHER  secretexpiryrecipients

### DIFF
--- a/auth/oidc/manageapplication.php
+++ b/auth/oidc/manageapplication.php
@@ -112,7 +112,9 @@ if ($form->is_cancelled()) {
     switch ($fromform->clientauthmethod) {
         case AUTH_OIDC_AUTH_METHOD_SECRET:
             $configstosave[] = 'clientsecret';
-            $configstosave[] = 'secretexpiryrecipients';
+            if ($fromform->idptype != AUTH_OIDC_IDP_TYPE_OTHER && auth_oidc_is_local_365_installed()) {
+                $configstosave[] = 'secretexpiryrecipients';
+            }
             break;
         case AUTH_OIDC_AUTH_METHOD_CERTIFICATE:
             $configstosave[] = 'clientcertsource';


### PR DESCRIPTION
field auth_oidc | secretexpiryrecipients used when o365 installed and idp not other, auth_method not secret (from  [settings.php](https://github.com/microsoft/o365-moodle/blob/cfa4b0fa1b47452f945623f80805aa4ed46cd892/auth/oidc/settings.php#L374-L387))
if we have another sit, then moodle raise the warning: "Undefined property: stdClass::$secretexpiryrecipients in manageapplication.php on line 138"