### PR TITLE
Convert calsync observers to async adhoc tasks

### DIFF
--- a/local/o365/classes/feature/calsync/observers.php
+++ b/local/o365/classes/feature/calsync/observers.php
@@ -118,8 +118,10 @@ class observers {
             return true;
         }
 
-        $calsync = new \local_o365\feature\calsync\main();
-        return $calsync->create_outlook_event_from_moodle_event($event->objectid);
+        $task = new \local_o365\feature\calsync\task\synccalendarevent();
+        $task->set_custom_data(['eventid' => $event->objectid, 'action' => 'create']);
+        \core\task\manager::queue_adhoc_task($task);
+        return true;
     }
 
     /**
@@ -133,8 +135,10 @@ class observers {
             return false;
         }
 
-        $calsync = new \local_o365\feature\calsync\main();
-        return $calsync->update_outlook_event($event->objectid);
+        $task = new \local_o365\feature\calsync\task\synccalendarevent();
+        $task->set_custom_data(['eventid' => $event->objectid, 'action' => 'update']);
+        \core\task\manager::queue_adhoc_task($task);
+        return true;
     }
 
     /**
@@ -148,11 +152,16 @@ class observers {
             return false;
         }
 
-        $calsync = new \local_o365\feature\calsync\main();
-
         $snapshot = $event->get_record_snapshot('event', $event->objectid);
 
-        return $calsync->delete_outlook_event($event->objectid, $snapshot);
+        $task = new \local_o365\feature\calsync\task\synccalendarevent();
+        $task->set_custom_data([
+            'eventid' => $event->objectid,
+            'action' => 'delete',
+            'snapshot' => ['courseid' => (int)$snapshot->courseid, 'groupid' => (int)$snapshot->groupid],
+        ]);
+        \core\task\manager::queue_adhoc_task($task);
+        return true;
     }
 
     /**

--- a/local/o365/classes/feature/calsync/task/synccalendarevent.php
+++ b/local/o365/classes/feature/calsync/task/synccalendarevent.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * AdHoc task to sync a single Moodle calendar event change with Microsoft Outlook.
+ *
+ * Queued by calsync observers instead of performing the sync synchronously,
+ * to avoid blocking web requests when courses have large enrolments.
+ *
+ * @package     local_o365
+ * @copyright   Enovation Solutions Ltd. {@link https://enovation.ie}
+ * @author      Patryk Mroczko <patryk.mroczko@enovation.ie>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_o365\feature\calsync\task;
+
+use local_o365\utils;
+
+/**
+ * AdHoc task to sync a single Moodle calendar event change with Microsoft Outlook.
+ *
+ * Custom data fields:
+ *   - int      eventid  The ID of the Moodle calendar event.
+ *   - string   action   One of 'create', 'update', or 'delete'.
+ *   - stdClass snapshot (delete only) The 'courseid' and 'groupid' of the event record, taken before deletion.
+ */
+class synccalendarevent extends \core\task\adhoc_task {
+    /**
+     * Execute the task.
+     *
+     * @return bool
+     */
+    public function execute(): bool {
+        global $DB;
+
+        if (utils::is_connected() !== true) {
+            return false;
+        }
+
+        $data = $this->get_custom_data();
+
+        $calsync = new \local_o365\feature\calsync\main();
+
+        switch ($data->action) {
+            case 'create':
+                if (!$DB->record_exists('event', ['id' => $data->eventid])) {
+                    return true;
+                }
+                $calsync->create_outlook_event_from_moodle_event($data->eventid);
+                break;
+
+            case 'update':
+                $calsync->update_outlook_event($data->eventid);
+                break;
+
+            case 'delete':
+                $snapshot = isset($data->snapshot) ? (object)$data->snapshot : null;
+                $calsync->delete_outlook_event($data->eventid, $snapshot);
+                break;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Synchronous Graph API calls in calendar event observers blocked web requests for minutes in courses with large enrolments. Replace direct sync calls with a new synccalendarevent adhoc task queued by each observer instead.