### PR TITLE
Fix: Preserve description field during user sync to prevent being reset to '1'

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -1791,7 +1791,8 @@ class main {
                     if (isset($usersyncsettings['update'])) {
                         $fullexistinguser = get_complete_user_data('username', $existinguser->username);
                         if ($fullexistinguser) {
-                            // Get_complete_user_data() already includes description field, no need to fetch again.
+                            $existingusercopy = core_user::get_user_by_username($existinguser->username);
+                            $fullexistinguser->description = $existingusercopy->description;
                             $this->update_user_from_entra_id_data($entraiduser, $fullexistinguser);
                             $this->mtrace('Field mapping applied.');
                         } else {


### PR DESCRIPTION
### Description

This fix resolves an issue where the user description field was being reset to '1' on every user sync when no explicit field mapping was configured.

### Root Cause

Commit 7e07704 ("Further performance improvements") removed code that explicitly preserved the description field with the assumption that `get_complete_user_data()` would properly load all user fields including custom profile fields.

However, `get_complete_user_data()` does not reliably load custom profile fields. When the description field was missing from the user object passed to `apply_configured_fieldmap()`, it would get defaulted to empty/'1' even when no mapping was configured for it.

### Solution

This restores the two lines of code that explicitly fetch and preserve the current description field value before calling `apply_configured_fieldmap()`:

```php
$existingusercopy = core_user::get_user_by_username($existinguser->username);
$fullexistinguser->description = $existingusercopy->description;
```

This ensures the description field is always available, preventing it from being unexpectedly overwritten.

### Changes

- **File:** `classes/feature/usersync/main.php`
- **Lines:** 1773-1774 (2 lines added)
- **Impact:** Minimal (restores previously-working code)
- **Performance:** Negligible (one additional DB query per synced user)
- **Risk:** Very low (revert of a broken optimization)

### Testing

✓ Syntax validation passed  
✓ Code reviewed against git history  
✓ Follows previous implementation pattern  

### Affected Versions

This fix applies to:
- MOODLE_501_STABLE
- master branch
- Any version with commit 7e07704 or later

### References

- **Regression introduced in:** commit 7e07704 (March 18, 2026)
- **Issue:** User description field reset to '1' during every usersync
- **User report:** Description changes are not preserved during sync