### PR TITLE
Added hook before_login_completed to plugin auth/oidc

### DIFF
--- a/auth/oidc/classes/hook/before_login_completed.php
+++ b/auth/oidc/classes/hook/before_login_completed.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace auth_oidc\hook;
+
+use auth_oidc\jwt;
+
+/**
+ * Allow plugins to callback as soon possible after user has completed login.
+ *
+ * @package    auth_oidc
+ * @copyright  2026 Ariadne
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+#[\core\attribute\label('Allow plugins to callback as soon possible after user has completed login.')]
+#[\core\attribute\tags('user', 'login')]
+class before_login_completed {
+    /**
+     * Constructor for the hook.
+     */
+    public function __construct(
+        /** @var jwt The course instance */
+        public readonly jwt $idtoken
+    ) {
+    }
+}

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -37,6 +37,7 @@ use moodle_exception;
 use moodle_url;
 use pix_icon;
 use stdClass;
+use core\di;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -659,6 +660,10 @@ class authcode extends base {
             $username = $user->username;
             $this->updatetoken($tokenrec->id, $authparams, $tokenparams);
             $user = authenticate_user_login($username, '', true);
+
+            // Look for plugins that want to add extra checks before user login is completed.
+            $hook = new \auth_oidc\hook\before_login_completed($idtoken);
+            di::get(\core\hook\manager::class)->dispatch($hook);
 
             if (!empty($user)) {
                 complete_user_login($user);


### PR DESCRIPTION
This commit aims to introduce the before_login_completed hook into the auth/oidc plugin to allow other plugins to perform extra checks before the user login is completed, for example preventing the login of a user who does not meet certain conditions.
