### PR TITLE
Fix Teams tab SSO broken by SameSite=Lax session cookies

### DIFF
--- a/local/o365/sso_login.php
+++ b/local/o365/sso_login.php
@@ -169,6 +169,26 @@ if (!$loginsuccess && !empty($payload->upn)) {
 }
 
 if ($loginsuccess) {
+    // Force theme.
+    $customtheme = get_config('local_o365', 'customtheme');
+    if (!empty($customtheme) && get_config('theme_' . $customtheme, 'version')) {
+        $SESSION->theme = $customtheme;
+    } else if (get_config('theme_boost_o365teams', 'version')) {
+        $SESSION->theme = 'boost_o365teams';
+    }
+
+    // The session cookie set by core carries SameSite=Lax (MDL-83526), which browsers reject in
+    // the cross-site iframe of the Teams tab, so re-emit it with "SameSite=None; Secure".
+    if (is_https() || !empty($CFG->sslproxy)) {
+        $cookieparams = session_get_cookie_params();
+        setcookie(session_name(), session_id(), [
+            'path' => $cookieparams['path'],
+            'domain' => $cookieparams['domain'],
+            'secure' => true,
+            'httponly' => $cookieparams['httponly'],
+            'samesite' => 'None',
+        ]);
+    }
     http_response_code(200);
 } else {
     http_response_code(401);


### PR DESCRIPTION
Since MDL-83526 (Moodle 4.5.12, 5.0.8, 5.1.5 and 5.2.1), core sets SameSite=Lax on the session cookie, which browsers reject in the cross-site iframe of the Teams tab. The SSO login in sso_login.php succeeded server-side, but the browser dropped the cookie and the subsequent course page request was anonymous, showing the login page.

Re-emit the session cookie with "SameSite=None; Secure" after a successful SSO login, mirroring the exception core makes for the Moodle mobile app.