### PR TITLE
Fix Outlook calendar sync for assignment extensions and availability changes

### DIFF
--- a/local/o365/classes/feature/calsync/form/element/calendar.php
+++ b/local/o365/classes/feature/calsync/form/element/calendar.php
@@ -48,6 +48,9 @@ class calendar extends \HTML_QuickForm_advcheckbox {
     /** @var string Sync behaviour: in/out/both. */
     protected $syncbehav = 'out';
 
+    /** @var array Form custom data. */
+    protected $customdata = [];
+
     /** @var string html for help button, if empty then no help will icon will be displayed. */
     public $_helpbutton = '';
 

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -204,11 +204,16 @@ class main {
     /**
      * Delete an event.
      *
+     * The calidmap row is only removed once the Outlook event has actually been deleted (or cleanup was
+     * otherwise handled, e.g. via calendar_unsubscribe()). If the delete is skipped (no resolvable Outlook
+     * UPN) or fails, the mapping is left in place - and a warning logged via mtrace() - rather than
+     * silently forgetting about an Outlook event that's still there.
+     *
      * @param bool $muserid
      * @param string $outlookeventid The event ID in o365 outlook.
      * @param int|null $idmaprecid
      *
-     * @return bool Success/Failure.
+     * @return bool Success/Failure - false if the delete was skipped or failed.
      */
     public function delete_event_raw($muserid, $outlookeventid, $idmaprecid = null) {
         global $DB;
@@ -241,26 +246,29 @@ class main {
         }
 
         if ($handled) {
-            if (!empty($idmaprecid)) {
-                $DB->delete_records('local_o365_calidmap', ['id' => $idmaprecid]);
-            } else {
-                $DB->delete_records('local_o365_calidmap', ['outlookeventid' => $outlookeventid]);
-            }
-
+            $DB->delete_records('local_o365_calidmap', ['id' => $idmaprecid]);
             return true;
         }
 
         $apiclient = $this->construct_calendar_api($muserid, true);
         $o365upn = utils::get_o365_upn($muserid);
-        if ($o365upn) {
-            $apiclient->delete_event($outlookeventid, $o365upn);
+        if (empty($o365upn)) {
+            // Can't resolve who to delete this as. Leave the mapping in place rather than silently
+            // forgetting about an Outlook event we never actually removed.
+            mtrace('Could not delete Outlook event for calidmap #' . $idmaprecid . ' - no Outlook UPN for user ' .
+                $muserid . '. Leaving the mapping in place.');
+            return false;
         }
 
-        if (!empty($idmaprecid)) {
-            $DB->delete_records('local_o365_calidmap', ['id' => $idmaprecid]);
-        } else {
-            $DB->delete_records('local_o365_calidmap', ['outlookeventid' => $outlookeventid]);
+        try {
+            $apiclient->delete_event($outlookeventid, $o365upn);
+        } catch (\moodle_exception $e) {
+            mtrace('Error deleting Outlook event for calidmap #' . $idmaprecid . ': ' . $e->getMessage() .
+                '. Leaving the mapping in place.');
+            return false;
         }
+
+        $DB->delete_records('local_o365_calidmap', ['id' => $idmaprecid]);
 
         return true;
     }
@@ -272,30 +280,20 @@ class main {
      * @return bool Success/Failure.
      */
     public function create_outlook_event_from_moodle_event($moodleventid) {
-        global $DB, $SITE;
+        global $DB;
 
         // Assemble basic event data.
         $event = $DB->get_record('event', ['id' => $moodleventid]);
-        $subject = $event->name;
+        $subject = $this->get_event_subject($event);
         $body = $event->description;
         $timestart = $event->timestart;
         $timeend = $timestart + $event->timeduration;
 
-        // Update event name.
-        if ($event->eventtype === 'site') {
-            $subject = $SITE->fullname . ': ' . $subject;
-        } else if ($event->eventtype === 'user') {
-            $subject = get_string('personal_calendar', 'local_o365') . ': ' . $subject;
-        } else if ($event->eventtype === 'course') {
-            $course = $DB->get_record('course', ['id' => $event->courseid]);
-            $subject = $course->fullname . ': ' . $subject;
-        }
-
         $body .= $this->get_event_link_html($event);
 
-        // Get attendees.
         if (isset($event->courseid) && $event->courseid == SITEID) {
-            // Site event.
+            // Site event. There's no group/M365-group concept at site level, so build the discovery
+            // array directly rather than going through get_course_event_attendees().
             $sql = 'SELECT u.id,
                            u.id as userid,
                            u.email,
@@ -308,57 +306,55 @@ class main {
                      WHERE sub.caltype = ? AND (sub.syncbehav = ? OR sub.syncbehav = ?)';
             $params = ['site', 'out', 'both'];
             $attendees = $DB->get_records_sql($sql, $params);
-        } else if (isset($event->courseid) && $event->courseid != SITEID && $event->courseid > 0) {
-            // Course event - Get subscribed students.
-            if (!empty($event->groupid)) {
-                $sql = 'SELECT u.id,
-                               u.id as userid,
-                               u.email,
-                               u.firstname,
-                               u.lastname,
-                               sub.isprimary as subisprimary,
-                               sub.o365calid as subo365calid
-                          FROM {user} u
-                          JOIN {user_enrolments} ue ON ue.userid = u.id
-                          JOIN {enrol} e ON e.id = ue.enrolid
-                          JOIN {local_o365_calsub} sub ON sub.user_id = u.id
-                               AND sub.caltype = ?
-                               AND sub.caltypeid = e.courseid
-                               AND (sub.syncbehav = ? OR sub.syncbehav = ?)
-                          JOIN {groups_members} grpmbr ON grpmbr.userid = u.id
-                         WHERE e.courseid = ? AND grpmbr.groupid = ?';
-                $params = ['course', 'out', 'both', $event->courseid, $event->groupid];
-                $attendees = $DB->get_records_sql($sql, $params);
-            } else {
-                $sql = 'SELECT u.id,
-                               u.id as userid,
-                               u.email,
-                               u.firstname,
-                               u.lastname,
-                               sub.isprimary as subisprimary,
-                               sub.o365calid as subo365calid
-                          FROM {user} u
-                          JOIN {user_enrolments} ue ON ue.userid = u.id
-                          JOIN {enrol} e ON e.id = ue.enrolid
-                          JOIN {local_o365_calsub} sub ON sub.user_id = u.id
-                               AND sub.caltype = ?
-                               AND sub.caltypeid = e.courseid
-                               AND (sub.syncbehav = ? OR sub.syncbehav = ?)
-                         WHERE e.courseid = ?';
-                $params = ['course', 'out', 'both', $event->courseid];
-                $attendees = $DB->get_records_sql($sql, $params);
 
-                // Retrieve the Outlook group objectid.
-                $groupobject = $DB->get_record(
-                    'local_o365_objects',
-                    ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-                );
+            $nonprimarycalsubs = [];
+            $eventcreatorsub = null;
+            foreach ($attendees as $userid => $attendee) {
+                if ($userid == $event->userid) {
+                    $eventcreatorsub = $attendee;
+                }
+
+                if (isset($attendee->subisprimary) && $attendee->subisprimary == '0') {
+                    $nonprimarycalsubs[] = $attendee;
+                    unset($attendees[$userid]);
+                }
             }
+
+            $discovery = [
+                'primary' => $attendees,
+                'nonprimary' => $nonprimarycalsubs,
+                'eventcreatorsub' => $eventcreatorsub,
+                'groupobject' => null,
+            ];
+        } else if (isset($event->courseid) && $event->courseid != SITEID && $event->courseid > 0) {
+            $discovery = $this->get_course_event_attendees($event);
         } else {
-            // Personal user event. Only sync if user is subscribed to their events.
+            // Personal user event.
+            if (!$this->is_event_module_visible_to_user($event, (int) $event->userid)) {
+                return true;
+            }
+
+            // Sync if the user is subscribed to their personal ("user") calendar. As a fallback,
+            // assignment extension events and user-override due dates (which Moodle always stores with
+            // courseid = 0, even though they belong to a specific course - see
+            // mod_assign::save_user_extension() and assign_update_events()) also sync if the user has
+            // subscribed to that assignment's course calendar, since most users only ever subscribe
+            // course calendars and would otherwise never see these synced at all.
             $select = 'caltype = ? AND user_id = ? AND (syncbehav = ? OR syncbehav = ?)';
             $params = ['user', $event->userid, 'out', 'both'];
             $calsub = $DB->get_record_select('local_o365_calsub', $select, $params);
+
+            $isassignpersonalduetype = $event->modulename === 'assign' &&
+                in_array($event->eventtype, ['extension', 'due'], true);
+            if (empty($calsub) && $isassignpersonalduetype) {
+                $assigncourseid = $DB->get_field('assign', 'course', ['id' => $event->instance]);
+                if (!empty($assigncourseid)) {
+                    $select = 'caltype = ? AND caltypeid = ? AND user_id = ? AND (syncbehav = ? OR syncbehav = ?)';
+                    $params = ['course', $assigncourseid, $event->userid, 'out', 'both'];
+                    $calsub = $DB->get_record_select('local_o365_calsub', $select, $params);
+                }
+            }
+
             if (!empty($calsub)) {
                 // Send event to o365 and store ID.
                 $apiclient = $this->construct_calendar_api($event->userid);
@@ -387,6 +383,88 @@ class main {
             return true;
         }
 
+        $this->create_combined_course_event($event, $discovery, $subject, $body, $timestart, $timeend);
+        $this->sync_nonprimary_attendees($event, $discovery['nonprimary'], $subject, $body, $timestart, $timeend);
+
+        return true;
+    }
+
+    /**
+     * Discover current, availability-filtered attendees for a course-level calendar event.
+     *
+     * Handles both group-restricted events (event->groupid set) and whole-course events, and splits the
+     * resulting attendees into primary-calendar (combined/group event) and non-primary-calendar
+     * (individually synced) groups, matching the different Outlook sync mechanisms used for each. Shared
+     * between create_outlook_event_from_moodle_event() and reconcile_course_event_attendees() so a later
+     * "Restrict access" change can be reconciled the same way the event was originally synced.
+     *
+     * @param \stdClass $event The Moodle event object (courseid must be a real, non-site course id).
+     * @return array {
+     *     primary: array of stdClass attendees (keyed by userid), eligible for the combined/group event.
+     *     nonprimary: array of stdClass attendees to sync individually.
+     *     eventcreatorsub: stdClass|null the event creator's own calsub row, if they're a primary attendee.
+     *     groupobject: stdClass|null the course's linked Microsoft 365 group object, if any (only looked
+     *                  up when the event isn't itself group-restricted, matching create_group_event()'s
+     *                  own gating).
+     * }
+     */
+    protected function get_course_event_attendees(\stdClass $event): array {
+        global $DB;
+
+        $groupobject = null;
+
+        if (!empty($event->groupid)) {
+            $sql = 'SELECT u.id,
+                           u.id as userid,
+                           u.email,
+                           u.firstname,
+                           u.lastname,
+                           sub.isprimary as subisprimary,
+                           sub.o365calid as subo365calid
+                      FROM {user} u
+                      JOIN {user_enrolments} ue ON ue.userid = u.id
+                      JOIN {enrol} e ON e.id = ue.enrolid
+                      JOIN {local_o365_calsub} sub ON sub.user_id = u.id
+                           AND sub.caltype = ?
+                           AND sub.caltypeid = e.courseid
+                           AND (sub.syncbehav = ? OR sub.syncbehav = ?)
+                      JOIN {groups_members} grpmbr ON grpmbr.userid = u.id
+                     WHERE e.courseid = ? AND grpmbr.groupid = ?';
+            $params = ['course', 'out', 'both', $event->courseid, $event->groupid];
+            $attendees = $DB->get_records_sql($sql, $params);
+        } else {
+            $sql = 'SELECT u.id,
+                           u.id as userid,
+                           u.email,
+                           u.firstname,
+                           u.lastname,
+                           sub.isprimary as subisprimary,
+                           sub.o365calid as subo365calid
+                      FROM {user} u
+                      JOIN {user_enrolments} ue ON ue.userid = u.id
+                      JOIN {enrol} e ON e.id = ue.enrolid
+                      JOIN {local_o365_calsub} sub ON sub.user_id = u.id
+                           AND sub.caltype = ?
+                           AND sub.caltypeid = e.courseid
+                           AND (sub.syncbehav = ? OR sub.syncbehav = ?)
+                     WHERE e.courseid = ?';
+            $params = ['course', 'out', 'both', $event->courseid];
+            $attendees = $DB->get_records_sql($sql, $params);
+
+            $groupobject = $DB->get_record(
+                'local_o365_objects',
+                ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
+            );
+        }
+
+        // Drop attendees who can't actually see the module this event belongs to (e.g. excluded by a
+        // group restriction), so they don't get an Outlook event for something hidden from them.
+        foreach ($attendees as $userid => $attendee) {
+            if (!$this->is_event_module_visible_to_user($event, (int) $userid)) {
+                unset($attendees[$userid]);
+            }
+        }
+
         // Move users who've subscribed to non-primary calendars.
         $nonprimarycalsubs = [];
         $eventcreatorsub = null;
@@ -401,63 +479,121 @@ class main {
             }
         }
 
-        $createdgroupevent = false;
-        if (isset($groupobject) && !empty($groupobject->objectid) && empty($event->groupid)) {
+        return [
+            'primary' => $attendees,
+            'nonprimary' => $nonprimarycalsubs,
+            'eventcreatorsub' => $eventcreatorsub,
+            'groupobject' => $groupobject,
+        ];
+    }
+
+    /**
+     * Create the combined "primary calendar attendees" event for a course/site-level event - either as a
+     * Microsoft 365 group calendar event (if the course has a linked group and the event isn't itself
+     * group-restricted) or as a single event with each primary-calendar attendee added as an Outlook
+     * attendee. No-ops if there are no eligible primary attendees.
+     *
+     * @param \stdClass $event The Moodle event object.
+     * @param array $discovery The result of get_course_event_attendees() (or an equivalent shape).
+     * @param string $subject The event's subject.
+     * @param string $body The event's body/description.
+     * @param int $timestart The event's start timestamp.
+     * @param int $timeend The event's end timestamp.
+     * @return void
+     */
+    protected function create_combined_course_event(
+        \stdClass $event,
+        array $discovery,
+        string $subject,
+        string $body,
+        int $timestart,
+        int $timeend
+    ): void {
+        global $DB;
+
+        $attendees = $discovery['primary'];
+        if (empty($attendees)) {
+            return;
+        }
+
+        $groupobject = $discovery['groupobject'];
+        $eventcreatorsub = $discovery['eventcreatorsub'];
+
+        if (!empty($groupobject) && !empty($groupobject->objectid) && empty($event->groupid)) {
             try {
-                if (!empty($attendees)) {
-                    $apiclient = $this->construct_calendar_api($event->userid);
-                    $response = $apiclient->create_group_event(
-                        $subject,
-                        $body,
-                        $timestart,
-                        $timeend,
-                        $attendees,
-                        ['responseRequested' => false],
-                        $groupobject->objectid
-                    );
-                    if (!empty($response)) {
-                        $idmaprec = [
-                            'eventid' => $event->id,
-                            'outlookeventid' => $response['Id'],
-                            'userid' => $event->userid,
-                            'origin' => 'moodle',
-                        ];
-                        $DB->insert_record('local_o365_calidmap', (object)$idmaprec);
-                        $createdgroupevent = true;
-                    }
+                $apiclient = $this->construct_calendar_api($event->userid);
+                $response = $apiclient->create_group_event(
+                    $subject,
+                    $body,
+                    $timestart,
+                    $timeend,
+                    $attendees,
+                    ['responseRequested' => false],
+                    $groupobject->objectid
+                );
+                if (!empty($response)) {
+                    $idmaprec = [
+                        'eventid' => $event->id,
+                        'outlookeventid' => $response['Id'],
+                        'userid' => $event->userid,
+                        'origin' => 'moodle',
+                    ];
+                    $DB->insert_record('local_o365_calidmap', (object) $idmaprec);
+                    return;
                 }
             } catch (moodle_exception $e) {
                 debugging('Error creating group event. Details: ' . $e->getMessage());
             }
         }
 
-        // Sync primary-calendar users as attendees on a single event.
-        if (!$createdgroupevent && !empty($attendees)) {
-            $apiclient = $this->construct_calendar_api($event->userid);
-            $calid = (!empty($eventcreatorsub) && !empty($eventcreatorsub->subo365calid)) ? $eventcreatorsub->subo365calid : null;
-            if (isset($eventcreatorsub->subisprimary) && $eventcreatorsub->subisprimary == 1) {
-                $calid = null;
-            }
-
-            $context = $this->get_calendar_context($event, $event->userid);
-            if (!empty($calid) && !$this->calendar_exists($event->userid, $calid)) {
-                $this->calendar_unsubscribe($event->userid, $context['caltype'], $context['caltypeid'], $calid);
-            } else {
-                $o365upn = utils::get_o365_upn($event->userid);
-                if ($o365upn) {
-                    $response = $apiclient->create_event($subject, $body, $timestart, $timeend, $attendees, [], $calid, $o365upn);
-                    $idmaprec = [
-                            'eventid' => $event->id,
-                            'outlookeventid' => $response['Id'],
-                            'userid' => $event->userid,
-                            'origin' => 'moodle',
-                    ];
-                    $DB->insert_record('local_o365_calidmap', (object) $idmaprec);
-                }
-            }
+        $apiclient = $this->construct_calendar_api($event->userid);
+        $calid = (!empty($eventcreatorsub) && !empty($eventcreatorsub->subo365calid)) ? $eventcreatorsub->subo365calid : null;
+        if (isset($eventcreatorsub->subisprimary) && $eventcreatorsub->subisprimary == 1) {
+            $calid = null;
         }
 
-        // Sync non-primary attendees individually.
+        $context = $this->get_calendar_context($event, $event->userid);
+        if (!empty($calid) && !$this->calendar_exists($event->userid, $calid)) {
+            $this->calendar_unsubscribe($event->userid, $context['caltype'], $context['caltypeid'], $calid);
+            return;
+        }
+
+        $o365upn = utils::get_o365_upn($event->userid);
+        if ($o365upn) {
+            $response = $apiclient->create_event($subject, $body, $timestart, $timeend, $attendees, [], $calid, $o365upn);
+            $idmaprec = [
+                'eventid' => $event->id,
+                'outlookeventid' => $response['Id'],
+                'userid' => $event->userid,
+                'origin' => 'moodle',
+            ];
+            $DB->insert_record('local_o365_calidmap', (object) $idmaprec);
+        }
+    }
+
+    /**
+     * Sync each given attendee's own copy of a course/site-level event individually - their own Outlook
+     * calendar, via their own token. Used for anyone subscribed to a non-primary/non-default Outlook
+     * calendar, since those can't be added as a plain Outlook "attendee" on someone else's combined event.
+     *
+     * @param \stdClass $event The Moodle event object.
+     * @param array $nonprimarycalsubs List of stdClass attendees to sync individually.
+     * @param string $subject The event's subject.
+     * @param string $body The event's body/description.
+     * @param int $timestart The event's start timestamp.
+     * @param int $timeend The event's end timestamp.
+     * @return void
+     */
+    protected function sync_nonprimary_attendees(
+        \stdClass $event,
+        array $nonprimarycalsubs,
+        string $subject,
+        string $body,
+        int $timestart,
+        int $timeend
+    ): void {
+        global $DB;
+
         foreach ($nonprimarycalsubs as $attendee) {
             $apiclient = $this->construct_calendar_api($attendee->id);
             $calid = (!empty($attendee->subo365calid)) ? $attendee->subo365calid : null;
@@ -478,6 +614,144 @@ class main {
                 ];
                 $DB->insert_record('local_o365_calidmap', (object)$idmaprec);
             }
+        }
+    }
+
+    /**
+     * Re-sync a course-level event's attendees after something that isn't reflected in the event itself
+     * changed who's eligible to see it - most notably, a course module's "Restrict access" rules being
+     * edited, which doesn't touch the calendar 'event' row at all, so calendar_event_updated never fires
+     * for it. Adds Outlook events for newly-eligible attendees and removes them for anyone who's lost
+     * access, without disturbing attendees whose eligibility hasn't changed.
+     *
+     * @param int $moodleeventid The ID of the Moodle event to reconcile.
+     * @return bool Success/Failure.
+     */
+    public function reconcile_course_event_attendees($moodleeventid) {
+        global $DB;
+
+        $event = $DB->get_record('event', ['id' => $moodleeventid]);
+        if (empty($event) || (int) $event->courseid === SITEID || empty($event->courseid)) {
+            // Not a course-level event - see reconcile_personal_event() for the personal-event equivalent.
+            return true;
+        }
+
+        $discovery = $this->get_course_event_attendees($event);
+
+        $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
+
+        $combinedidmaprec = null;
+        $individualidmaprecsbyuserid = [];
+        foreach ($idmaprecs as $idmaprec) {
+            if ((int) $idmaprec->userid === (int) $event->userid) {
+                $combinedidmaprec = $idmaprec;
+            } else {
+                $individualidmaprecsbyuserid[(int) $idmaprec->userid] = $idmaprec;
+            }
+        }
+
+        $eligiblenonprimaryuserids = array_map(static function ($attendee) {
+            return (int) $attendee->userid;
+        }, $discovery['nonprimary']);
+
+        // Remove individually-synced attendees who are no longer eligible.
+        foreach ($individualidmaprecsbyuserid as $userid => $idmaprec) {
+            if (!in_array($userid, $eligiblenonprimaryuserids, true)) {
+                $this->delete_event_raw($userid, $idmaprec->outlookeventid, $idmaprec->id);
+            }
+        }
+
+        $subject = $this->get_event_subject($event);
+        $body = $event->description . $this->get_event_link_html($event);
+        $timestart = $event->timestart;
+        $timeend = $timestart + $event->timeduration;
+
+        // Add individual events for newly-eligible non-primary attendees.
+        $newlyeligiblenonprimary = array_filter(
+            $discovery['nonprimary'],
+            static function ($attendee) use ($individualidmaprecsbyuserid) {
+                return !isset($individualidmaprecsbyuserid[(int) $attendee->userid]);
+            }
+        );
+        $this->sync_nonprimary_attendees($event, $newlyeligiblenonprimary, $subject, $body, $timestart, $timeend);
+
+        // Reconcile the combined (primary-calendar / group) event's attendee list.
+        if (!empty($combinedidmaprec)) {
+            if (empty($discovery['primary'])) {
+                // No eligible primary-calendar attendees left - remove the shared event entirely.
+                $this->delete_event_raw((int) $combinedidmaprec->userid, $combinedidmaprec->outlookeventid, $combinedidmaprec->id);
+            } else {
+                $this->update_combined_course_event_attendees($event, $discovery, $combinedidmaprec);
+            }
+        } else {
+            // There was no combined event before (e.g. no eligible primary attendees at the time it was
+            // first created) - create one now if there's anyone to put in it.
+            $this->create_combined_course_event($event, $discovery, $subject, $body, $timestart, $timeend);
+        }
+
+        return true;
+    }
+
+    /**
+     * Push an updated attendee list to an already-synced combined (primary-calendar or group) course
+     * event, without touching its subject/body/time.
+     *
+     * @param \stdClass $event The Moodle event object.
+     * @param array $discovery The result of get_course_event_attendees($event).
+     * @param \stdClass $idmaprec The calidmap row for the combined event.
+     * @return void
+     */
+    protected function update_combined_course_event_attendees(\stdClass $event, array $discovery, \stdClass $idmaprec): void {
+        $groupobject = $discovery['groupobject'];
+        $isgroupevent = !empty($groupobject) && !empty($groupobject->objectid) && empty($event->groupid);
+
+        $apiclient = $this->construct_calendar_api($idmaprec->userid);
+        $updated = ['attendees' => $discovery['primary']];
+
+        try {
+            if ($isgroupevent) {
+                $apiclient->update_event($idmaprec->outlookeventid, $updated, $groupobject->objectid, 'group');
+            } else {
+                $o365upn = utils::get_o365_upn($idmaprec->userid);
+                if ($o365upn) {
+                    $apiclient->update_event($idmaprec->outlookeventid, $updated, $o365upn);
+                }
+            }
+        } catch (\moodle_exception $e) {
+            mtrace('Error updating attendees for calidmap #' . $idmaprec->id . ': ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Re-sync a personal (courseid = 0) event - e.g. an assignment extension or user override - after
+     * something outside the event itself changed whether the owning user can see it. Creates the Outlook
+     * event if it's newly eligible and not yet synced, or removes it if the user has lost access.
+     *
+     * @param int $moodleeventid The ID of the Moodle event to reconcile.
+     * @return bool Success/Failure.
+     */
+    public function reconcile_personal_event($moodleeventid) {
+        global $DB;
+
+        $event = $DB->get_record('event', ['id' => $moodleeventid]);
+        if (empty($event) || !empty($event->courseid)) {
+            // Not a personal event - see reconcile_course_event_attendees() for the course-level equivalent.
+            return true;
+        }
+
+        $idmaprec = $DB->get_record('local_o365_calidmap', ['eventid' => $moodleeventid, 'userid' => $event->userid]);
+        $visible = $this->is_event_module_visible_to_user($event, (int) $event->userid);
+
+        if (!empty($idmaprec)) {
+            if (!$visible) {
+                $this->delete_event_raw((int) $event->userid, $idmaprec->outlookeventid, $idmaprec->id);
+            }
+
+            return true;
+        }
+
+        if ($visible) {
+            return $this->create_outlook_event_from_moodle_event($moodleeventid);
         }
 
         return true;
@@ -526,7 +800,7 @@ class main {
      * @return bool Success/Failure.
      */
     public function update_outlook_event($moodleeventid) {
-        global $DB, $SITE;
+        global $DB;
 
         // Get o365 event id (and determine if we can sync this event).
         $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
@@ -541,21 +815,11 @@ class main {
         }
 
         $updated = [
-            'subject' => $event->name,
+            'subject' => $this->get_event_subject($event),
             'body' => $event->description,
             'starttime' => $event->timestart,
             'endtime' => $event->timestart + $event->timeduration,
         ];
-
-        // Update event name.
-        if ($event->eventtype === 'site') {
-            $updated['subject'] = $SITE->fullname . ': ' . $updated['subject'];
-        } else if ($event->eventtype === 'user') {
-            $updated['subject'] = get_string('personal_calendar', 'local_o365') . ': ' . $updated['subject'];
-        } else if ($event->eventtype === 'course') {
-            $course = $DB->get_record('course', ['id' => $event->courseid]);
-            $updated['subject'] = $course->fullname . ': ' . $updated['subject'];
-        }
 
         $updated['body'] .= $this->get_event_link_html($event);
 
@@ -571,6 +835,18 @@ class main {
         }
 
         foreach ($idmaprecs as $idmaprec) {
+            // If the user has since lost access to the module (e.g. a group restriction was added or
+            // they were moved out of an allowed group), remove their synced Outlook event instead of
+            // updating it.
+            if (!$this->is_event_module_visible_to_user($event, (int) $idmaprec->userid)) {
+                try {
+                    $this->delete_event_raw($idmaprec->userid, $idmaprec->outlookeventid, $idmaprec->id);
+                } catch (\moodle_exception $e) {
+                    mtrace('Error deleting event: ' . $e->getMessage());
+                }
+                continue;
+            }
+
             $context = $this->get_calendar_context($event, $idmaprec->userid);
             if (!empty($context['calid']) && !$this->calendar_exists($idmaprec->userid, $context['calid'])) {
                 $this->calendar_unsubscribe($idmaprec->userid, $context['caltype'], $context['caltypeid'], $context['calid']);
@@ -580,7 +856,11 @@ class main {
             try {
                 $apiclient = $this->construct_calendar_api($idmaprec->userid);
 
-                if ($isgroupevent) {
+                // See the matching comment in delete_outlook_event() - a calidmap row not recorded under
+                // the event's own creator identity was created individually, never via the group API.
+                $isrecipientgroupevent = $isgroupevent && (int) $idmaprec->userid === (int) $event->userid;
+
+                if ($isrecipientgroupevent) {
                     try {
                         $apiclient->update_event($idmaprec->outlookeventid, $updated, $groupobject->objectid, 'group');
                         continue;
@@ -607,11 +887,61 @@ class main {
     }
 
     /**
+     * Push a new start time for an already-synced Moodle event to Outlook.
+     *
+     * Used for cases where a Moodle event's timestart has been (or is about to be) changed via direct
+     * SQL rather than through the calendar_event API, so the normal \core\event\calendar_event_updated
+     * event never fires. mod_assign's assignment extension re-grant is one such case. Everything other
+     * than the start time is read fresh from the Moodle event record, since only the start time is stale
+     * at the point this is called.
+     *
+     * @param int $moodleeventid The ID of the Moodle event to update.
+     * @param int $newtimestart The new start timestamp to push to Outlook.
+     * @return bool Always true - per-recipient failures (e.g. a Graph API error) are logged via mtrace()
+     *              and skipped rather than surfaced here, matching update_outlook_event().
+     */
+    public function update_outlook_event_datetime($moodleeventid, $newtimestart) {
+        global $DB;
+
+        $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
+        if (empty($idmaprecs)) {
+            return true;
+        }
+
+        $event = $DB->get_record('event', ['id' => $moodleeventid]);
+        if (empty($event)) {
+            return true;
+        }
+
+        $updated = [
+            'subject' => $this->get_event_subject($event),
+            'body' => $event->description . $this->get_event_link_html($event),
+            'starttime' => $newtimestart,
+            'endtime' => $newtimestart + $event->timeduration,
+        ];
+
+        foreach ($idmaprecs as $idmaprec) {
+            try {
+                $this->update_event_raw($idmaprec->userid, $idmaprec->outlookeventid, $updated);
+            } catch (\moodle_exception $e) {
+                mtrace('Error updating event: ' . $e->getMessage());
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Delete all synced Outlook events for a given Moodle event.
+     *
+     * A calidmap row is only removed once we've confirmed its Outlook event was actually deleted (or that
+     * cleanup was otherwise handled, e.g. via calendar_unsubscribe()). Recipients whose delete attempt was
+     * skipped (no resolvable Outlook UPN) or failed keep their mapping so they aren't silently forgotten -
+     * a warning is logged via mtrace() for each one so it's visible in cron output.
      *
      * @param int $moodleeventid The ID of a Moodle event.
      * @param stdClass|null $eventsnapshot Snapshot of the Moodle event.
-     * @return bool Success/Failure.
+     * @return bool Always true - see above for how per-recipient failures are handled.
      */
     public function delete_outlook_event($moodleeventid, ?\stdClass $eventsnapshot) {
         global $DB;
@@ -637,38 +967,64 @@ class main {
 
         foreach ($idmaprecs as $idmaprec) {
             if (!empty($event)) {
-                $context = $this->get_calendar_context($event, (int)$idmaprec->userid);
+                $context = $this->get_calendar_context($event, (int) $idmaprec->userid);
 
                 if (!empty($context['calid']) && !$this->calendar_exists($idmaprec->userid, $context['calid'])) {
                     $this->calendar_unsubscribe($idmaprec->userid, $context['caltype'], $context['caltypeid'], $context['calid']);
+                    $DB->delete_records('local_o365_calidmap', ['id' => $idmaprec->id]);
                     continue;
                 }
             }
 
             $apiclient = $this->construct_calendar_api($idmaprec->userid);
+            $deleted = false;
 
-            if ($isgroupevent) {
+            // Creation only ever records the group/combined-primary event under the event's own creator
+            // identity ($event->userid). A calidmap row recorded under any other userid was created
+            // individually, for that specific attendee's own calendar (the "non-primary calendar
+            // subscribers" loop) - never the group calendar - so it must always be deleted via that
+            // attendee's own UPN, not the group API.
+            $isrecipientgroupevent = $isgroupevent && !empty($event) && (int) $idmaprec->userid === (int) $event->userid;
+
+            if ($isrecipientgroupevent) {
                 try {
                     $apiclient->delete_event($idmaprec->outlookeventid, $groupobject->objectid, 'group');
-                    continue;
+                    $deleted = true;
                 } catch (\moodle_exception $e) {
                     $o365upn = utils::get_o365_upn($idmaprec->userid);
-                    if ($o365upn) {
-                        $apiclient->delete_event($idmaprec->outlookeventid, $o365upn);
+                    if (empty($o365upn)) {
+                        mtrace('Error deleting group event for calidmap #' . $idmaprec->id . ': ' . $e->getMessage() .
+                            ' (no Outlook UPN fallback for user ' . $idmaprec->userid . '). Leaving the mapping in place.');
+                    } else {
+                        try {
+                            $apiclient->delete_event($idmaprec->outlookeventid, $o365upn);
+                            $deleted = true;
+                        } catch (\moodle_exception $e2) {
+                            mtrace('Error deleting event (group and user fallback both failed) for calidmap #' .
+                                $idmaprec->id . ': ' . $e2->getMessage() . '. Leaving the mapping in place.');
+                        }
                     }
-
-                    continue;
+                }
+            } else {
+                $o365upn = utils::get_o365_upn($idmaprec->userid);
+                if (empty($o365upn)) {
+                    mtrace('Could not delete Outlook event for calidmap #' . $idmaprec->id . ' - no Outlook UPN for user ' .
+                        $idmaprec->userid . '. Leaving the mapping in place.');
+                } else {
+                    try {
+                        $apiclient->delete_event($idmaprec->outlookeventid, $o365upn);
+                        $deleted = true;
+                    } catch (\moodle_exception $e) {
+                        mtrace('Error deleting Outlook event for calidmap #' . $idmaprec->id . ': ' . $e->getMessage() .
+                            '. Leaving the mapping in place.');
+                    }
                 }
             }
 
-            $o365upn = utils::get_o365_upn($idmaprec->userid);
-            if ($o365upn) {
-                $apiclient->delete_event($idmaprec->outlookeventid, $o365upn);
+            if ($deleted) {
+                $DB->delete_records('local_o365_calidmap', ['id' => $idmaprec->id]);
             }
         }
-
-        // Clean up idmap table.
-        $DB->delete_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
 
         return true;
     }
@@ -706,6 +1062,34 @@ class main {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Build the Outlook event subject for a Moodle calendar event.
+     *
+     * Prefixes the event's name with contextual information (site/personal/course name), matching what
+     * a user would see if they navigated to the equivalent view in Moodle's own calendar. Pulled out into
+     * its own method so every place that pushes a subject to Outlook (create, update, and the
+     * calendar_event-API-bypassing update_outlook_event_datetime()) builds it the same way.
+     *
+     * @param \stdClass $event The Moodle event database object.
+     * @return string The subject to use for the Outlook event.
+     */
+    protected function get_event_subject(\stdClass $event): string {
+        global $DB, $SITE;
+
+        $subject = $event->name;
+
+        if ($event->eventtype === 'site') {
+            $subject = $SITE->fullname . ': ' . $subject;
+        } else if ($event->eventtype === 'user') {
+            $subject = get_string('personal_calendar', 'local_o365') . ': ' . $subject;
+        } else if ($event->eventtype === 'course') {
+            $course = $DB->get_record('course', ['id' => $event->courseid]);
+            $subject = $course->fullname . ': ' . $subject;
+        }
+
+        return $subject;
     }
 
     /**
@@ -860,5 +1244,66 @@ class main {
         $calendarid = ($calsub && (int)$calsub->isprimary === 0) ? $calsub->o365calid : null;
 
         return ['caltype' => $calendartype, 'caltypeid' => $calendartypeid, 'calid' => $calendarid];
+    }
+
+    /**
+     * Check whether the course module a calendar event belongs to is visible to a given user.
+     *
+     * This mirrors the check the Moodle calendar UI itself applies when deciding whether to show an
+     * event to a user (see calendar_get_view() in calendar/lib.php), so that "Restrict access" rules
+     * (e.g. group-based restrictions) are respected when deciding who gets a synced Outlook event too.
+     * Events that aren't tied to a specific course module (e.g. manually-created course/site events)
+     * are always considered visible, since there's no module-level restriction to check.
+     *
+     * As a cheap pre-check, if the course module is visible and has no availability restrictions
+     * configured at all, it's visible to every user, so the far more expensive per-user modinfo lookup
+     * (which builds a full course_modinfo and evaluates the availability tree) is skipped entirely. That
+     * lookup only runs for modules that are actually hidden or have restrictions configured - for a large
+     * course's attendee list, that's the exception rather than the rule.
+     *
+     * @param \stdClass $event The Moodle event object.
+     * @param int $userid The Moodle user ID to check visibility for.
+     * @return bool True if the event isn't tied to a module, or the module is visible to the user.
+     */
+    protected function is_event_module_visible_to_user(\stdClass $event, int $userid): bool {
+        global $DB;
+
+        if (empty($event->modulename) || empty($event->instance) || empty($event->courseid)) {
+            return true;
+        }
+
+        static $cmcache = [];
+        $cachekey = $event->courseid . ':' . $event->modulename . ':' . $event->instance;
+
+        if (!array_key_exists($cachekey, $cmcache)) {
+            $sql = "SELECT cm.visible, cm.availability
+                      FROM {course_modules} cm
+                      JOIN {modules} m ON m.id = cm.module
+                     WHERE m.name = :modulename AND cm.instance = :instance AND cm.course = :courseid";
+            $params = ['modulename' => $event->modulename, 'instance' => $event->instance, 'courseid' => $event->courseid];
+            $cmcache[$cachekey] = $DB->get_record_sql($sql, $params);
+        }
+
+        $cm = $cmcache[$cachekey];
+        if (empty($cm)) {
+            // No matching course module - it's most likely been deleted. Default to "not visible" so we
+            // don't keep syncing (or create) an Outlook event for something that no longer exists.
+            return false;
+        }
+
+        if ((int) $cm->visible === 1 && empty($cm->availability)) {
+            // Nothing is configured to hide this module from anyone - no need for a per-user check.
+            return true;
+        }
+
+        $modinfo = \get_fast_modinfo($event->courseid, $userid);
+        $usercm = $modinfo->instances[$event->modulename][$event->instance] ?? null;
+
+        if (empty($usercm)) {
+            // Same reasoning as above - couldn't resolve the module, so don't assume it's visible.
+            return false;
+        }
+
+        return $usercm->uservisible;
     }
 }

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -451,10 +451,12 @@ class main {
             $params = ['course', 'out', 'both', $event->courseid];
             $attendees = $DB->get_records_sql($sql, $params);
 
+            // DB::get_record() returns false (not null) when nothing matches - normalise here so downstream
+            // code can rely on it being either a real record or null, never false.
             $groupobject = $DB->get_record(
                 'local_o365_objects',
                 ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-            );
+            ) ?: null;
         }
 
         // Drop attendees who can't actually see the module this event belongs to (e.g. excluded by a
@@ -842,10 +844,12 @@ class main {
         $isgroupevent = false;
 
         if ($event->courseid !== SITEID && $event->courseid !== 0 && empty($event->groupid)) {
+            // DB::get_record() returns false (not null) when nothing matches - normalise here so
+            // delete_calidmap_rows()'s ?stdClass parameter doesn't get handed a bare false.
             $groupobject = $DB->get_record(
                 'local_o365_objects',
                 ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-            );
+            ) ?: null;
             $isgroupevent = !empty($groupobject) && !empty($groupobject->objectid);
         }
 
@@ -969,10 +973,12 @@ class main {
         $groupobject = null;
 
         if (!empty($event) && $event->courseid !== SITEID && $event->courseid !== 0 && empty($event->groupid)) {
+            // DB::get_record() returns false (not null) when nothing matches - normalise here so
+            // delete_calidmap_rows()'s ?stdClass parameter doesn't get handed a bare false.
             $groupobject = $DB->get_record(
                 'local_o365_objects',
                 ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-            );
+            ) ?: null;
         }
 
         $this->delete_calidmap_rows($event, $idmaprecs, $groupobject);

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -1314,7 +1314,22 @@ class main {
                       JOIN {modules} m ON m.id = cm.module
                      WHERE m.name = :modulename AND cm.instance = :instance AND cm.course = :courseid";
             $params = ['modulename' => $event->modulename, 'instance' => $event->instance, 'courseid' => $event->courseid];
-            $cmcache[$cachekey] = $DB->get_record_sql($sql, $params);
+            $cm = $DB->get_record_sql($sql, $params);
+            $cmcache[$cachekey] = $cm;
+
+            // A date-based "Restrict access" rule has nothing to observe - unlike a group restriction
+            // being edited, or a user's group membership changing, visibility just becomes true as time
+            // passes, with no event firing to react to. Every other trigger for this method (creation,
+            // update, reconciliation) only re-evaluates visibility in response to something happening, so
+            // without this, a date-restricted event would only ever end up synced by coincidence (e.g. if
+            // the date happened to already be in the past when something else triggered a sync). Schedule
+            // a one-off recheck at the exact moment the restriction could next take effect instead.
+            if (!empty($cm) && !empty($cm->availability)) {
+                $nextchange = $this->get_next_availability_date($cm->availability);
+                if ($nextchange !== null) {
+                    $this->schedule_availability_recheck($event->modulename, (int) $event->instance, $nextchange);
+                }
+            }
         }
 
         $cm = $cmcache[$cachekey];
@@ -1338,5 +1353,90 @@ class main {
         }
 
         return $usercm->uservisible;
+    }
+
+    /**
+     * Find the earliest still-upcoming timestamp among any date-based "Restrict access" conditions
+     * anywhere in a course module's availability tree (course_modules.availability, JSON-encoded).
+     *
+     * This deliberately doesn't try to evaluate the tree's AND/OR/NOT logic - it just collects every
+     * date condition's timestamp, regardless of nesting, and returns the soonest one still in the future.
+     * That can occasionally schedule a recheck that turns out to be a no-op (e.g. a date condition
+     * ANDed with an unrelated, still-unsatisfied condition), which is harmless; the alternative - missing
+     * a genuine visibility change - is not.
+     *
+     * @param string|null $availabilityjson The raw availability JSON from course_modules.availability.
+     * @return int|null The earliest future timestamp, or null if there isn't one.
+     */
+    protected function get_next_availability_date(?string $availabilityjson): ?int {
+        if (empty($availabilityjson)) {
+            return null;
+        }
+
+        $tree = json_decode($availabilityjson);
+        if (empty($tree)) {
+            return null;
+        }
+
+        $now = time();
+        $next = null;
+
+        $walk = static function ($node) use (&$walk, &$next, $now) {
+            if (empty($node)) {
+                return;
+            }
+
+            if (is_array($node)) {
+                foreach ($node as $child) {
+                    $walk($child);
+                }
+                return;
+            }
+
+            if (!is_object($node)) {
+                return;
+            }
+
+            if (isset($node->type) && $node->type === 'date' && isset($node->t)) {
+                $time = (int) $node->t;
+                if ($time > $now && ($next === null || $time < $next)) {
+                    $next = $time;
+                }
+            }
+
+            if (isset($node->c) && is_array($node->c)) {
+                $walk($node->c);
+            }
+        };
+
+        $walk($tree);
+
+        return $next;
+    }
+
+    /**
+     * Schedule a one-off adhoc task to re-check Outlook sync for a module at the moment a date-based
+     * "Restrict access" condition could next take effect. Deduplicated (per module and target time) via
+     * queue_adhoc_task()'s $checkforexisting, so repeated calls for the same still-pending date don't pile
+     * up duplicate tasks; the target time is included in the custom data specifically so that, if the
+     * restriction is later edited to a different date, that's treated as a distinct task rather than being
+     * silently skipped as "already scheduled".
+     *
+     * @param string $modulename The module type (e.g. 'assign').
+     * @param int $instanceid The module instance ID.
+     * @param int $timestamp The timestamp the restriction could next take effect.
+     * @return void
+     */
+    protected function schedule_availability_recheck(string $modulename, int $instanceid, int $timestamp): void {
+        $task = new \local_o365\feature\calsync\task\syncmoduleavailability();
+        $task->set_custom_data([
+            'modulename' => $modulename,
+            'instanceid' => $instanceid,
+            'scheduledfor' => $timestamp,
+        ]);
+        // A few seconds of slack after the threshold, so the recheck doesn't race the exact instant the
+        // restriction takes effect.
+        $task->set_next_run_time($timestamp + 5);
+        \core\task\manager::queue_adhoc_task($task, true);
     }
 }

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -640,11 +640,18 @@ class main {
 
         $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
 
-        $combinedidmaprec = null;
+        // Every mapping recorded under the event's own creator identity is a candidate "combined" mapping
+        // (see create_combined_course_event()). Normally there's at most one, but {event}.userid isn't
+        // stable - Moodle's calendar_event::create() refills it from $USER->id whenever mod_assign passes
+        // an empty value, which happens on every assignment save - so an earlier reconciliation pass can
+        // fail to recognise an already-synced mapping and create a second one alongside it. Collect every
+        // match here (rather than keeping only the last one seen) so duplicates like that get cleaned up
+        // instead of leaving one permanently orphaned.
+        $combinedidmaprecs = [];
         $individualidmaprecsbyuserid = [];
         foreach ($idmaprecs as $idmaprec) {
             if ((int) $idmaprec->userid === (int) $event->userid) {
-                $combinedidmaprec = $idmaprec;
+                $combinedidmaprecs[] = $idmaprec;
             } else {
                 $individualidmaprecsbyuserid[(int) $idmaprec->userid] = $idmaprec;
             }
@@ -676,12 +683,20 @@ class main {
         $this->sync_nonprimary_attendees($event, $newlyeligiblenonprimary, $subject, $body, $timestart, $timeend);
 
         // Reconcile the combined (primary-calendar / group) event's attendee list.
-        if (!empty($combinedidmaprec)) {
+        if (!empty($combinedidmaprecs)) {
             if (empty($discovery['primary'])) {
-                // No eligible primary-calendar attendees left - remove the shared event entirely.
-                $this->delete_event_raw((int) $combinedidmaprec->userid, $combinedidmaprec->outlookeventid, $combinedidmaprec->id);
+                // No eligible primary-calendar attendees left - remove every shared-event mapping. Routed
+                // through delete_calidmap_rows() (not delete_event_raw()) since it correctly detects and
+                // deletes via the group API when the mapping is a Microsoft 365 group calendar event.
+                $this->delete_calidmap_rows($event, $combinedidmaprecs, $discovery['groupobject']);
             } else {
-                $this->update_combined_course_event_attendees($event, $discovery, $combinedidmaprec);
+                // Keep and update the first mapping found; if duplicates have accumulated, remove the
+                // rest rather than leaving them behind untouched.
+                $primarycombined = array_shift($combinedidmaprecs);
+                $this->update_combined_course_event_attendees($event, $discovery, $primarycombined);
+                if (!empty($combinedidmaprecs)) {
+                    $this->delete_calidmap_rows($event, $combinedidmaprecs, $discovery['groupobject']);
+                }
             }
         } else {
             // There was no combined event before (e.g. no eligible primary attendees at the time it was
@@ -837,13 +852,10 @@ class main {
         foreach ($idmaprecs as $idmaprec) {
             // If the user has since lost access to the module (e.g. a group restriction was added or
             // they were moved out of an allowed group), remove their synced Outlook event instead of
-            // updating it.
+            // updating it. Routed through delete_calidmap_rows() rather than delete_event_raw() directly,
+            // since it correctly detects and deletes via the group API when this is a group calendar event.
             if (!$this->is_event_module_visible_to_user($event, (int) $idmaprec->userid)) {
-                try {
-                    $this->delete_event_raw($idmaprec->userid, $idmaprec->outlookeventid, $idmaprec->id);
-                } catch (\moodle_exception $e) {
-                    mtrace('Error deleting event: ' . $e->getMessage());
-                }
+                $this->delete_calidmap_rows($event, [$idmaprec], $groupobject);
                 continue;
             }
 
@@ -955,15 +967,37 @@ class main {
         $event = $eventsnapshot;
 
         $groupobject = null;
-        $isgroupevent = false;
 
         if (!empty($event) && $event->courseid !== SITEID && $event->courseid !== 0 && empty($event->groupid)) {
             $groupobject = $DB->get_record(
                 'local_o365_objects',
                 ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
             );
-            $isgroupevent = !empty($groupobject) && !empty($groupobject->objectid);
         }
+
+        $this->delete_calidmap_rows($event, $idmaprecs, $groupobject);
+
+        return true;
+    }
+
+    /**
+     * Delete a set of already-synced Outlook events, correctly routing group-calendar mappings through
+     * the group API instead of always using the individual-user endpoint (unlike delete_event_raw(),
+     * which has no way to know a mapping might be a group event).
+     *
+     * A calidmap row is only removed once we've confirmed its Outlook event was actually deleted (or that
+     * cleanup was otherwise handled, e.g. via calendar_unsubscribe()). Anything skipped (no resolvable
+     * Outlook UPN) or failed is left in place and logged via mtrace(), rather than silently forgotten.
+     *
+     * @param \stdClass|null $event The Moodle event object the mappings belong to. Null disables the
+     *                              calendar-subscription check and group-event detection (matches the
+     *                              behaviour when no event snapshot is available).
+     * @param array $idmaprecs The local_o365_calidmap rows to delete.
+     * @param \stdClass|null $groupobject The course's linked Microsoft 365 group object, if any.
+     * @return void
+     */
+    protected function delete_calidmap_rows(?\stdClass $event, array $idmaprecs, ?\stdClass $groupobject): void {
+        global $DB;
 
         foreach ($idmaprecs as $idmaprec) {
             if (!empty($event)) {
@@ -984,7 +1018,8 @@ class main {
             // individually, for that specific attendee's own calendar (the "non-primary calendar
             // subscribers" loop) - never the group calendar - so it must always be deleted via that
             // attendee's own UPN, not the group API.
-            $isrecipientgroupevent = $isgroupevent && !empty($event) && (int) $idmaprec->userid === (int) $event->userid;
+            $isrecipientgroupevent = !empty($groupobject) && !empty($groupobject->objectid) && !empty($event) &&
+                empty($event->groupid) && (int) $idmaprec->userid === (int) $event->userid;
 
             if ($isrecipientgroupevent) {
                 try {
@@ -1025,8 +1060,6 @@ class main {
                 $DB->delete_records('local_o365_calidmap', ['id' => $idmaprec->id]);
             }
         }
-
-        return true;
     }
 
     /**

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -284,6 +284,13 @@ class main {
 
         // Assemble basic event data.
         $event = $DB->get_record('event', ['id' => $moodleventid]);
+
+        if ($this->is_grading_due_event($event)) {
+            // Due-to-be-graded reminders are for teachers/graders, not the whole subscribed-course
+            // attendee list that due-date events use - never sync them to Outlook.
+            return true;
+        }
+
         $subject = $this->get_event_subject($event);
         $body = $event->description;
         $timestart = $event->timestart;
@@ -638,9 +645,20 @@ class main {
             return true;
         }
 
-        $discovery = $this->get_course_event_attendees($event);
-
         $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
+
+        if ($this->is_grading_due_event($event)) {
+            // Should never be synced (see create_outlook_event_from_moodle_event()) - clean up any
+            // mappings left over from before this exclusion existed, rather than leaving them orphaned.
+            if (!empty($idmaprecs)) {
+                $discovery = $this->get_course_event_attendees($event);
+                $this->delete_calidmap_rows($event, $idmaprecs, $discovery['groupobject']);
+            }
+
+            return true;
+        }
+
+        $discovery = $this->get_course_event_attendees($event);
 
         // Every mapping recorded under the event's own creator identity is a candidate "combined" mapping
         // (see create_combined_course_event()). Normally there's at most one, but {event}.userid isn't
@@ -851,6 +869,13 @@ class main {
                 ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
             ) ?: null;
             $isgroupevent = !empty($groupobject) && !empty($groupobject->objectid);
+        }
+
+        if ($this->is_grading_due_event($event)) {
+            // Should never be synced (see create_outlook_event_from_moodle_event()) - clean up any
+            // mappings left over from before this exclusion existed, rather than pushing a stale update.
+            $this->delete_calidmap_rows($event, $idmaprecs, $groupobject);
+            return true;
         }
 
         foreach ($idmaprecs as $idmaprec) {
@@ -1101,6 +1126,20 @@ class main {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Check whether a calendar event is an assignment's "due to be graded" reminder.
+     *
+     * mod_assign creates this as a plain course-level event (ASSIGN_EVENT_TYPE_GRADINGDUE), so without
+     * this check it would end up in the same subscribed-course attendee list that due-date events use -
+     * but it's a teacher/grader-facing reminder, not something students should get an Outlook event for.
+     *
+     * @param \stdClass $event The Moodle event object.
+     * @return bool True if this is a "due to be graded" reminder that should never be synced.
+     */
+    protected function is_grading_due_event(\stdClass $event): bool {
+        return $event->modulename === 'assign' && $event->eventtype === 'gradingdue';
     }
 
     /**

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -1346,19 +1346,24 @@ class main {
     protected function is_event_module_visible_to_user(\stdClass $event, int $userid): bool {
         global $DB;
 
-        if (empty($event->modulename) || empty($event->instance) || empty($event->courseid)) {
+        if (empty($event->modulename) || empty($event->instance)) {
             return true;
         }
 
+        // Personal events (assignment extensions, user overrides) are always stored with courseid = 0,
+        // even though they're tied to a real module in a real course - so $event->courseid can't be used
+        // to look up the course module here. modulename+instance already uniquely identifies exactly one
+        // course_modules row regardless of course (instance is the module's own globally-unique id), so
+        // the course is resolved from that row instead of trusted from the event.
         static $cmcache = [];
-        $cachekey = $event->courseid . ':' . $event->modulename . ':' . $event->instance;
+        $cachekey = $event->modulename . ':' . $event->instance;
 
         if (!array_key_exists($cachekey, $cmcache)) {
-            $sql = "SELECT cm.visible, cm.availability
+            $sql = "SELECT cm.course, cm.visible, cm.availability
                       FROM {course_modules} cm
                       JOIN {modules} m ON m.id = cm.module
-                     WHERE m.name = :modulename AND cm.instance = :instance AND cm.course = :courseid";
-            $params = ['modulename' => $event->modulename, 'instance' => $event->instance, 'courseid' => $event->courseid];
+                     WHERE m.name = :modulename AND cm.instance = :instance";
+            $params = ['modulename' => $event->modulename, 'instance' => $event->instance];
             $cm = $DB->get_record_sql($sql, $params);
             $cmcache[$cachekey] = $cm;
 
@@ -1389,7 +1394,7 @@ class main {
             return true;
         }
 
-        $modinfo = \get_fast_modinfo($event->courseid, $userid);
+        $modinfo = \get_fast_modinfo($cm->course, $userid);
         $usercm = $modinfo->instances[$event->modulename][$event->instance] ?? null;
 
         if (empty($usercm)) {

--- a/local/o365/classes/feature/calsync/observers.php
+++ b/local/o365/classes/feature/calsync/observers.php
@@ -150,7 +150,10 @@ class observers {
 
         $calsync = new \local_o365\feature\calsync\main();
 
-        $snapshot = $event->get_record_snapshot('event', $event->objectid);
+        // Falls back to a raw DB::get_record() call (returning false, not null) if no snapshot was
+        // explicitly attached - normalise here so delete_outlook_event()'s ?stdClass parameter doesn't
+        // get handed a bare false.
+        $snapshot = $event->get_record_snapshot('event', $event->objectid) ?: null;
 
         return $calsync->delete_outlook_event($event->objectid, $snapshot);
     }

--- a/local/o365/classes/feature/calsync/observers.php
+++ b/local/o365/classes/feature/calsync/observers.php
@@ -156,6 +156,92 @@ class observers {
     }
 
     /**
+     * Handle a course_module_updated event.
+     *
+     * Editing a course module's "Restrict access" rules (or anything else affecting who can see it)
+     * doesn't touch the calendar 'event' row at all, so no calendar_event_updated fires and the normal
+     * observers never re-evaluate Outlook sync for it. Moodle's own calendar looks correct regardless,
+     * since it recomputes visibility live on every render (see is_event_module_visible_to_user() in
+     * \local_o365\feature\calsync\main) - but Outlook sync is event-driven, so it needs an explicit
+     * trigger. course_module_updated doesn't tell us specifically whether availability changed, so this
+     * queues a reconciliation task for every calendar event tied to the module on every edit.
+     *
+     * @param \core\event\course_module_updated $event The triggered event.
+     * @return bool Success/Failure.
+     */
+    public static function handle_course_module_updated(\core\event\course_module_updated $event) {
+        if (\local_o365\utils::is_connected() !== true) {
+            return false;
+        }
+
+        $modulename = $event->other['modulename'] ?? null;
+        $instanceid = $event->other['instanceid'] ?? null;
+
+        if (empty($modulename) || empty($instanceid)) {
+            return true;
+        }
+
+        $task = new \local_o365\feature\calsync\task\syncmoduleavailability();
+        $task->set_custom_data([
+            'modulename' => $modulename,
+            'instanceid' => $instanceid,
+        ]);
+        \core\task\manager::queue_adhoc_task($task);
+
+        return true;
+    }
+
+    /**
+     * Handle a group_member_added event.
+     *
+     * A group-based "Restrict access" rule doesn't just change when the rule itself is edited - it also
+     * changes whenever the affected user's group membership changes, which editing the module obviously
+     * doesn't cover. See handle_group_member_removed() and queue_user_availability_sync() for details.
+     *
+     * @param \core\event\group_member_added $event The triggered event.
+     * @return bool Success/Failure.
+     */
+    public static function handle_group_member_added(\core\event\group_member_added $event) {
+        return static::queue_user_availability_sync($event->courseid, $event->relateduserid);
+    }
+
+    /**
+     * Handle a group_member_removed event.
+     *
+     * @param \core\event\group_member_removed $event The triggered event.
+     * @return bool Success/Failure.
+     */
+    public static function handle_group_member_removed(\core\event\group_member_removed $event) {
+        return static::queue_user_availability_sync($event->courseid, $event->relateduserid);
+    }
+
+    /**
+     * Queue an adhoc task to re-check Outlook sync for one user's group-restricted events in a course.
+     *
+     * @param int $courseid The course the group membership change happened in.
+     * @param int $userid The user whose group membership changed.
+     * @return bool Success/Failure.
+     */
+    protected static function queue_user_availability_sync($courseid, $userid) {
+        if (\local_o365\utils::is_connected() !== true) {
+            return false;
+        }
+
+        if (empty($courseid) || empty($userid)) {
+            return true;
+        }
+
+        $task = new \local_o365\feature\calsync\task\syncuseravailability();
+        $task->set_custom_data([
+            'courseid' => $courseid,
+            'userid' => $userid,
+        ]);
+        \core\task\manager::queue_adhoc_task($task);
+
+        return true;
+    }
+
+    /**
      * Handle calendar_subscribed event - queue calendar sync jobs for cron.
      *
      * @param \local_o365\event\calendar_subscribed $event The triggered event.
@@ -198,6 +284,78 @@ class observers {
             'timecreated' => time(),
         ]);
         \core\task\manager::queue_adhoc_task($calunsubscribe);
+        return true;
+    }
+
+    /**
+     * Handle a mod_assign extension_granted event.
+     *
+     * mod_assign\assign::save_user_extension() updates or deletes the underlying calendar 'event' record
+     * with direct SQL when an extension is re-granted or revoked, bypassing calendar_event::update() and
+     * calendar_event::delete(). This means \core\event\calendar_event_updated/deleted never fire for those
+     * two cases, so the normal calendar sync observers never see the change.
+     *
+     * extension_granted itself, however, is always triggered - for grants, re-grants, and revokes alike -
+     * and it fires before that raw SQL runs. Registering this as an internal (synchronous) observer means
+     * it executes at that same point: assign_user_flags has already been saved with the new extension
+     * date, but the 'event' table still holds the pre-change record. That lets us diff old vs. new state
+     * to work out what needs reconciling in Outlook for the two cases core's own events miss. A
+     * first-time grant needs no special handling here, since core creates the event via
+     * calendar_event::create(), which fires calendar_event_created and is handled normally by
+     * handle_calendar_event_created().
+     *
+     * This only does cheap, local DB reads/writes. The actual Outlook sync involves outbound Graph API
+     * calls, which would add latency to the teacher's grant-extension request and hold this request's
+     * transaction open for longer than necessary if made inline here - so instead this only captures a
+     * snapshot of what changed and queues an adhoc task (\local_o365\feature\calsync\task\
+     * syncassignextension) to make those calls after the request has committed.
+     *
+     * @param \mod_assign\event\extension_granted $event The triggered event.
+     * @return bool Success/Failure.
+     */
+    public static function handle_assign_extension_granted(\mod_assign\event\extension_granted $event) {
+        global $DB;
+
+        if (\local_o365\utils::is_connected() !== true) {
+            return false;
+        }
+
+        $assignid = $event->objectid;
+        $userid = $event->relateduserid;
+
+        $flags = $DB->get_record('assign_user_flags', ['assignment' => $assignid, 'userid' => $userid]);
+        $newextensionduedate = (!empty($flags)) ? (int) $flags->extensionduedate : 0;
+
+        // Still the pre-change record - see method docblock.
+        $oldevent = $DB->get_record('event', [
+            'modulename' => 'assign',
+            'instance' => $assignid,
+            'userid' => $userid,
+            'eventtype' => 'extension',
+        ]);
+
+        if (empty($oldevent)) {
+            return true;
+        }
+
+        if (empty($newextensionduedate)) {
+            // Extension is being revoked - core is about to delete the event record directly.
+            $action = 'delete';
+        } else if ((int) $oldevent->timestart !== $newextensionduedate) {
+            // Extension date is being changed - core is about to update the event record directly.
+            $action = 'update';
+        } else {
+            return true;
+        }
+
+        $task = new \local_o365\feature\calsync\task\syncassignextension();
+        $task->set_custom_data([
+            'action' => $action,
+            'event' => $oldevent,
+            'newextensionduedate' => $newextensionduedate,
+        ]);
+        \core\task\manager::queue_adhoc_task($task);
+
         return true;
     }
 

--- a/local/o365/classes/feature/calsync/task/syncassignextension.php
+++ b/local/o365/classes/feature/calsync/task/syncassignextension.php
@@ -1,0 +1,65 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * AdHoc task to sync a mod_assign extension change with Outlook.
+ *
+ * @package local_o365
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\feature\calsync\task;
+
+use local_o365\utils;
+use moodle_exception;
+
+/**
+ * AdHoc task to sync a mod_assign extension change with Outlook.
+ *
+ * mod_assign\assign::save_user_extension() updates or deletes the underlying calendar 'event' record
+ * with direct SQL rather than through calendar_event::update()/delete() when an extension is re-granted
+ * or revoked, so the generic calendar_event_updated/deleted events never fire for those changes. This
+ * task is queued by \local_o365\feature\calsync\observers::handle_assign_extension_granted() - which
+ * captures a snapshot of the pre-change event plus the new extension date - to make the corresponding
+ * outbound Graph API calls after the triggering request has committed, rather than making them inline
+ * during the teacher's grant-extension request.
+ */
+class syncassignextension extends \core\task\adhoc_task {
+    /**
+     * Do the job.
+     */
+    public function execute() {
+        if (utils::is_connected() !== true) {
+            return;
+        }
+
+        $data = $this->get_custom_data();
+        $event = (object) (array) $data->event;
+
+        $calsync = new \local_o365\feature\calsync\main();
+
+        try {
+            if ($data->action === 'delete') {
+                $calsync->delete_outlook_event($event->id, $event);
+            } else if ($data->action === 'update') {
+                $calsync->update_outlook_event_datetime($event->id, (int) $data->newextensionduedate);
+            }
+        } catch (moodle_exception $e) {
+            mtrace('Error syncing assignment extension for event #' . $event->id . ': ' . $e->getMessage());
+        }
+    }
+}

--- a/local/o365/classes/feature/calsync/task/syncmoduleavailability.php
+++ b/local/o365/classes/feature/calsync/task/syncmoduleavailability.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * AdHoc task to re-sync Outlook events for a course module after its availability may have changed.
+ *
+ * @package local_o365
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\feature\calsync\task;
+
+use local_o365\utils;
+use moodle_exception;
+
+/**
+ * AdHoc task to re-sync Outlook events for a course module after its availability may have changed.
+ *
+ * Queued by \local_o365\feature\calsync\observers::handle_course_module_updated() whenever a course
+ * module is edited, since editing "Restrict access" rules doesn't touch the calendar 'event' table at
+ * all and so never fires the events the normal calendar sync observers listen for.
+ */
+class syncmoduleavailability extends \core\task\adhoc_task {
+    /**
+     * Do the job.
+     */
+    public function execute() {
+        global $DB;
+
+        if (utils::is_connected() !== true) {
+            return;
+        }
+
+        $data = $this->get_custom_data();
+
+        $events = $DB->get_records('event', ['modulename' => $data->modulename, 'instance' => $data->instanceid]);
+        if (empty($events)) {
+            return;
+        }
+
+        $calsync = new \local_o365\feature\calsync\main();
+
+        foreach ($events as $event) {
+            try {
+                if (!empty($event->courseid)) {
+                    $calsync->reconcile_course_event_attendees($event->id);
+                } else {
+                    $calsync->reconcile_personal_event($event->id);
+                }
+            } catch (moodle_exception $e) {
+                mtrace('Error reconciling Outlook sync for event #' . $event->id . ': ' . $e->getMessage());
+            }
+        }
+    }
+}

--- a/local/o365/classes/feature/calsync/task/syncmoduleavailability.php
+++ b/local/o365/classes/feature/calsync/task/syncmoduleavailability.php
@@ -25,7 +25,6 @@
 namespace local_o365\feature\calsync\task;
 
 use local_o365\utils;
-use moodle_exception;
 
 /**
  * AdHoc task to re-sync Outlook events for a course module after its availability may have changed.
@@ -61,7 +60,9 @@ class syncmoduleavailability extends \core\task\adhoc_task {
                 } else {
                     $calsync->reconcile_personal_event($event->id);
                 }
-            } catch (moodle_exception $e) {
+            } catch (\Throwable $e) {
+                // Catches \Error (e.g. a coding bug like a TypeError) as well as moodle_exception, so one
+                // bad event can't silently abort reconciliation for the rest of this module's events.
                 mtrace('Error reconciling Outlook sync for event #' . $event->id . ': ' . $e->getMessage());
             }
         }

--- a/local/o365/classes/feature/calsync/task/syncuseravailability.php
+++ b/local/o365/classes/feature/calsync/task/syncuseravailability.php
@@ -1,0 +1,95 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * AdHoc task to re-sync a user's Outlook events after their group membership changed.
+ *
+ * @package local_o365
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\feature\calsync\task;
+
+use local_o365\utils;
+use moodle_exception;
+
+/**
+ * AdHoc task to re-sync a user's Outlook events after their group membership changed.
+ *
+ * Queued by \local_o365\feature\calsync\observers::handle_group_member_added()/
+ * handle_group_member_removed(), since a group-based "Restrict access" rule can change who a module is
+ * visible to purely from a group membership change, without the module itself ever being edited (which
+ * is the only thing \local_o365\feature\calsync\task\syncmoduleavailability reacts to).
+ *
+ * Scoped to modules that actually have an availability rule configured, to avoid needlessly pushing a
+ * redundant Outlook "update attendees" call for every course event whenever any group membership changes
+ * anywhere in the course.
+ */
+class syncuseravailability extends \core\task\adhoc_task {
+    /**
+     * Do the job.
+     */
+    public function execute() {
+        global $DB;
+
+        if (utils::is_connected() !== true) {
+            return;
+        }
+
+        $data = $this->get_custom_data();
+        $courseid = $data->courseid;
+        $userid = $data->userid;
+
+        $calsync = new \local_o365\feature\calsync\main();
+
+        // Course-level events (e.g. due dates): reconcile the whole attendee list, since a combined or
+        // group event is shared with every eligible attendee, not just the user whose membership changed.
+        $sql = "SELECT ev.*
+                  FROM {event} ev
+                  JOIN {course_modules} cm ON cm.instance = ev.instance
+                  JOIN {modules} m ON m.id = cm.module AND m.name = ev.modulename
+                 WHERE ev.courseid = :courseid
+                       AND cm.availability IS NOT NULL AND cm.availability <> :empty1";
+        $courseevents = $DB->get_records_sql($sql, ['courseid' => $courseid, 'empty1' => '']);
+        foreach ($courseevents as $event) {
+            try {
+                $calsync->reconcile_course_event_attendees($event->id);
+            } catch (moodle_exception $e) {
+                mtrace('Error reconciling Outlook sync for event #' . $event->id . ': ' . $e->getMessage());
+            }
+        }
+
+        // Personal events (extensions, user overrides) tied to a restricted module in this course,
+        // belonging to the specific user whose group membership changed.
+        $sql = "SELECT ev.*
+                  FROM {event} ev
+                  JOIN {course_modules} cm ON cm.instance = ev.instance
+                  JOIN {modules} m ON m.id = cm.module AND m.name = ev.modulename
+                 WHERE cm.course = :courseid
+                       AND ev.courseid = 0
+                       AND ev.userid = :userid
+                       AND cm.availability IS NOT NULL AND cm.availability <> :empty2";
+        $personalevents = $DB->get_records_sql($sql, ['courseid' => $courseid, 'userid' => $userid, 'empty2' => '']);
+        foreach ($personalevents as $event) {
+            try {
+                $calsync->reconcile_personal_event($event->id);
+            } catch (moodle_exception $e) {
+                mtrace('Error reconciling Outlook sync for event #' . $event->id . ': ' . $e->getMessage());
+            }
+        }
+    }
+}

--- a/local/o365/classes/feature/calsync/task/syncuseravailability.php
+++ b/local/o365/classes/feature/calsync/task/syncuseravailability.php
@@ -25,7 +25,6 @@
 namespace local_o365\feature\calsync\task;
 
 use local_o365\utils;
-use moodle_exception;
 
 /**
  * AdHoc task to re-sync a user's Outlook events after their group membership changed.
@@ -68,7 +67,10 @@ class syncuseravailability extends \core\task\adhoc_task {
         foreach ($courseevents as $event) {
             try {
                 $calsync->reconcile_course_event_attendees($event->id);
-            } catch (moodle_exception $e) {
+            } catch (\Throwable $e) {
+                // Catches \Error (e.g. a coding bug like a TypeError) as well as moodle_exception, so one
+                // bad event can't silently abort reconciliation for the rest of this course's events - or,
+                // for this loop specifically, prevent the personal-events loop below from ever running.
                 mtrace('Error reconciling Outlook sync for event #' . $event->id . ': ' . $e->getMessage());
             }
         }
@@ -87,7 +89,9 @@ class syncuseravailability extends \core\task\adhoc_task {
         foreach ($personalevents as $event) {
             try {
                 $calsync->reconcile_personal_event($event->id);
-            } catch (moodle_exception $e) {
+            } catch (\Throwable $e) {
+                // Catches \Error (e.g. a coding bug like a TypeError) as well as moodle_exception, so one
+                // bad event can't silently abort reconciliation for the rest of this user's events.
                 mtrace('Error reconciling Outlook sync for event #' . $event->id . ': ' . $e->getMessage());
             }
         }

--- a/local/o365/db/events.php
+++ b/local/o365/db/events.php
@@ -59,6 +59,24 @@ $observers = [
         'internal'    => false,
     ],
     [
+        'eventname'   => '\core\event\course_module_updated',
+        'callback'    => '\local_o365\feature\calsync\observers::handle_course_module_updated',
+        'priority'    => 200,
+        'internal'    => false,
+    ],
+    [
+        'eventname'   => '\core\event\group_member_added',
+        'callback'    => '\local_o365\feature\calsync\observers::handle_group_member_added',
+        'priority'    => 200,
+        'internal'    => false,
+    ],
+    [
+        'eventname'   => '\core\event\group_member_removed',
+        'callback'    => '\local_o365\feature\calsync\observers::handle_group_member_removed',
+        'priority'    => 200,
+        'internal'    => false,
+    ],
+    [
         'eventname'   => '\local_o365\event\calendar_subscribed',
         'callback'    => '\local_o365\feature\calsync\observers::handle_calendar_subscribed',
         'priority'    => 200,
@@ -75,6 +93,12 @@ $observers = [
         'callback'    => '\local_o365\feature\calsync\observers::handle_user_deleted',
         'priority'    => 200,
         'internal'    => false,
+    ],
+    [
+        'eventname'   => '\mod_assign\event\extension_granted',
+        'callback'    => '\local_o365\feature\calsync\observers::handle_assign_extension_granted',
+        'priority'    => 200,
+        'internal'    => true,
     ],
 
     // Events from auth_oidc.

--- a/local/o365/version.php
+++ b/local/o365/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025100602;
+$plugin->version = 2025100602.02;
 $plugin->requires = 2025100600;
 $plugin->release = '5.1.2';
 $plugin->component = 'local_o365';


### PR DESCRIPTION
- Fix extension grant/revoke not syncing, since mod_assign bypasses the calendar_event API with raw SQL; add an observer + adhoc task to catch it
- Fix extensions and user-override due dates silently not syncing unless the user has a personal (not just course) calendar subscription
- Respect "Restrict access" rules when syncing to Outlook, matching the visibility check Moodle's own calendar UI already applies
- Fix Outlook events silently failing to delete/update without being retried or logged, permanently orphaning them
- Fix individually-synced attendees being wrongly routed through the Microsoft 365 group API instead of their own calendar
- Add observer + adhoc task to re-sync Outlook events when a module's availability rules are edited
- Add observer + adhoc task to re-sync Outlook events when a user's group membership changes
- Refactor attendee discovery and event creation into shared methods used by both initial sync and reconciliation
- Fix PHP 8.2 dynamic property deprecation in calendar form element