### PR TITLE
Adds a before_login_completed hook to auth_oidc

### DIFF
--- a/auth/oidc/classes/hook/before_login_completed.php
+++ b/auth/oidc/classes/hook/before_login_completed.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace auth_oidc\hook;
+
+use auth_oidc\jwt;
+
+/**
+ * Allow plugins to callback as soon possible after user has completed login.
+ *
+ * @package    auth_oidc
+ * @copyright  2026 Ariadne
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+#[\core\attribute\label('Allow plugins to callback as soon possible after user has completed login.')]
+#[\core\attribute\tags('user', 'login')]
+class before_login_completed {
+    /**
+     * Constructor for the hook.
+     */
+    public function __construct(
+        /** @var jwt The course instance */
+        public readonly jwt $idtoken
+    ) {
+    }
+}

--- a/auth/oidc/classes/hook/before_login_completed.php
+++ b/auth/oidc/classes/hook/before_login_completed.php
@@ -19,20 +19,31 @@ namespace auth_oidc\hook;
 use auth_oidc\jwt;
 
 /**
- * Allow plugins to callback as soon possible after user has completed login.
+ * Allow plugins to perform additional checks before a user login is completed.
+ *
+ * This hook is dispatched by auth_oidc after authenticate_user_login() has
+ * succeeded, but before complete_user_login() is called. The hook manager
+ * does not catch exceptions raised by callbacks, so a callback can reject
+ * the login by throwing an exception (e.g. \moodle_exception) - doing so
+ * will propagate out of the hook dispatch and prevent complete_user_login()
+ * from being called. There is no other signal (e.g. a flag on this hook) to
+ * reject the login; a plain return from a callback allows the login to
+ * proceed.
  *
  * @package    auth_oidc
  * @copyright  2026 Ariadne
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-#[\core\attribute\label('Allow plugins to callback as soon possible after user has completed login.')]
+#[\core\attribute\label('Allow plugins to perform additional checks before a user login is completed.')]
 #[\core\attribute\tags('user', 'login')]
 class before_login_completed {
     /**
      * Constructor for the hook.
+     *
+     * @param jwt $idtoken The id_token of the user attempting to log in.
      */
     public function __construct(
-        /** @var jwt The course instance */
+        /** @var jwt The id_token of the user attempting to log in */
         public readonly jwt $idtoken
     ) {
     }

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -38,6 +38,7 @@ use moodle_exception;
 use core\url;
 use pix_icon;
 use stdClass;
+use core\di;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -737,6 +738,10 @@ class authcode extends base {
             $username = $user->username;
             $this->updatetoken($tokenrec->id, $authparams, $tokenparams);
             $user = authenticate_user_login($username, '', true);
+
+            // Look for plugins that want to add extra checks before user login is completed.
+            $hook = new \auth_oidc\hook\before_login_completed($idtoken);
+            di::get(\core\hook\manager::class)->dispatch($hook);
 
             if (!empty($user)) {
                 complete_user_login($user);

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -739,11 +739,11 @@ class authcode extends base {
             $this->updatetoken($tokenrec->id, $authparams, $tokenparams);
             $user = authenticate_user_login($username, '', true);
 
-            // Look for plugins that want to add extra checks before user login is completed.
-            $hook = new \auth_oidc\hook\before_login_completed($idtoken);
-            di::get(\core\hook\manager::class)->dispatch($hook);
-
             if (!empty($user)) {
+                // Look for plugins that want to add extra checks before user login is completed.
+                $hook = new \auth_oidc\hook\before_login_completed($idtoken);
+                di::get(\core\hook\manager::class)->dispatch($hook);
+
                 complete_user_login($user);
             } else {
                 // There was a problem in authenticate_user_login.
@@ -814,6 +814,10 @@ class authcode extends base {
             $user = authenticate_user_login($username, '', true);
 
             if (!empty($user)) {
+                // Look for plugins that want to add extra checks before user login is completed.
+                $hook = new \auth_oidc\hook\before_login_completed($idtoken);
+                di::get(\core\hook\manager::class)->dispatch($hook);
+
                 complete_user_login($user);
             } else {
                 // There was a problem in authenticate_user_login.
@@ -900,6 +904,11 @@ class authcode extends base {
                     $updatedtokenrec->userid = $user->id;
                     $DB->update_record('auth_oidc_token', $updatedtokenrec);
                 }
+
+                // Look for plugins that want to add extra checks before user login is completed.
+                $hook = new \auth_oidc\hook\before_login_completed($idtoken);
+                di::get(\core\hook\manager::class)->dispatch($hook);
+
                 complete_user_login($user);
             } else {
                 // There was a problem in authenticate_user_login. Clean up incomplete token record.


### PR DESCRIPTION
Adds a before_login_completed hook to auth_oidc so plugins can reject a login before it completes.