### PR TITLE
Fix CSRF in ajax.php enabling privilege escalation by requiring sessk…

### DIFF
--- a/local/o365/ajax.php
+++ b/local/o365/ajax.php
@@ -30,6 +30,7 @@ require_once(__DIR__ . '/../../config.php');
 require_login();
 $mode = required_param('mode', PARAM_TEXT);
 require_capability('moodle/site:config', system::instance());
+require_sesskey();
 $url = '/local/o365/ajax.php';
 $page = new \local_o365\page\ajax($url, '');
 $page->run($mode);

--- a/local/o365/classes/adminsetting/moodlesetup.php
+++ b/local/o365/classes/adminsetting/moodlesetup.php
@@ -92,7 +92,7 @@ class moodlesetup extends \admin_setting {
         $scripturl = new url('/local/o365/classes/adminsetting/moodlesetup.js');
         $settinghtml .= '<script src="' . $scripturl->out() . '"></script>';
 
-        $ajaxurl = new url('/local/o365/ajax.php');
+        $ajaxurl = new url('/local/o365/ajax.php', ['sesskey' => sesskey()]);
         $settinghtml .= '<script>
                             $(function() {
                                 var opts = {

--- a/local/o365/classes/adminsetting/serviceresource.php
+++ b/local/o365/classes/adminsetting/serviceresource.php
@@ -90,7 +90,7 @@ class serviceresource extends admin_setting_configtext {
             $iconvalid = addslashes($OUTPUT->pix_icon('t/check', 'valid', 'moodle'));
             $iconinvalid = addslashes($OUTPUT->pix_icon('t/delete', 'invalid', 'moodle'));
             $iconloading = addslashes($OUTPUT->pix_icon('i/ajaxloader', 'loading', 'moodle'));
-            $ajaxurl = new url('/local/o365/ajax.php');
+            $ajaxurl = new url('/local/o365/ajax.php', ['sesskey' => sesskey()]);
             $settinghtml .= '<script>
                                 $(function() {
                                     var opts = {

--- a/local/o365/classes/adminsetting/verifysetup.php
+++ b/local/o365/classes/adminsetting/verifysetup.php
@@ -118,7 +118,7 @@ class verifysetup extends \admin_setting {
 
         $unifiedenabled = 'true';
 
-        $ajaxurl = new url('/local/o365/ajax.php');
+        $ajaxurl = new url('/local/o365/ajax.php', ['sesskey' => sesskey()]);
         $settinghtml .= '<script>
 $(function() {
     var opts = {


### PR DESCRIPTION
…ey validation

local/o365/ajax.php required only require_login() and moodle/site:config, with no sesskey check on any of its state-changing modes. mode_checkteamsmoodlesetup in particular enables web services, the REST protocol, frame embedding, the bundled o365_webservices external service, and grants moodle/webservice:createtoken and webservice/rest:use to the default authenticated-user role - all unconditionally, on a simple GET request. A forged cross-site request against a logged-in administrator (e.g. via an <img> tag) silently expands these permissions to every authenticated user, regardless of whether the site uses Teams SSO at all.

Add require_sesskey() to ajax.php, and append sesskey to the ajax.php URL built by the three admin_setting classes that call it (moodlesetup, verifysetup, serviceresource). These build their AJAX calls with plain jQuery rather than a sesskey-aware core JS module, so the sesskey is carried in the URL's query string instead, where jQuery's GET request serialization appends the remaining parameters.