### PR TITLE
Fix record deletion condition error in deleteinvalidconfiglog task

### DIFF
--- a/local/o365/classes/task/deleteinvalidconfiglog.php
+++ b/local/o365/classes/task/deleteinvalidconfiglog.php
@@ -112,7 +112,8 @@ class deleteinvalidconfiglog extends adhoc_task {
                     //
                     // This avoids full table scans on unindexed columns (eventname, objectid).
                     $deletechunks = array_chunk($configlogids, self::DELETE_CHUNK_SIZE);
-                    $totaldeleted = 0;
+                    $totalconfigdeleted = 0;
+                    $totallogstoredeleted = 0;
 
                     foreach ($deletechunks as $chunk) {
                         // First, get the config_log records with their timemodified values.
@@ -177,7 +178,7 @@ class deleteinvalidconfiglog extends adhoc_task {
                                 $DB->delete_records_list('logstore_standard_log', 'id', $microchunk);
                                 usleep(50000); // 0.05 seconds between micro-deletes.
                             }
-                            $totaldeleted += count($logidstodelete);
+                            $totallogstoredeleted += count($logidstodelete);
                             mtrace("... Deleted " . count($logidstodelete) . " logstore records for chunk");
                         }
 
@@ -186,12 +187,13 @@ class deleteinvalidconfiglog extends adhoc_task {
                         // removed by \logstore_standard\task\cleanup_task (loglifetime setting), while
                         // config_log is never purged by Moodle, so a match is not guaranteed.
                         $DB->delete_records_list('config_log', 'id', $chunk);
-                        $totaldeleted += count($chunk);
+                        $totalconfigdeleted += count($chunk);
                         mtrace("... Deleted " . count($chunk) . " config_log records for chunk");
 
                         // Check if we've exceeded the maximum execution time.
                         if (time() >= $starttime + self::MAX_EXECUTION_TIME) {
-                            mtrace("... Reached time limit. Processed {$totaldeleted} records so far.");
+                            mtrace("... Reached time limit. Processed {$totalconfigdeleted} config_log records " .
+                                "and {$totallogstoredeleted} logstore records so far.");
                             $hasmore = true;
                             break 2; // Break out of both foreach loops.
                         }

--- a/local/o365/classes/task/deleteinvalidconfiglog.php
+++ b/local/o365/classes/task/deleteinvalidconfiglog.php
@@ -179,23 +179,24 @@ class deleteinvalidconfiglog extends adhoc_task {
                             }
                             $totaldeleted += count($logidstodelete);
                             mtrace("... Deleted " . count($logidstodelete) . " logstore records for chunk");
-
-                            // Delete config_log records for this chunk immediately after logstore deletion.
-                            // This ensures atomic per-chunk processing: either both tables are cleaned up,
-                            // or neither is touched. Prevents orphaning logstore deletions on timeout.
-                            $DB->delete_records_list('config_log', 'id', $chunk);
-                            mtrace("... Deleted " . count($chunk) . " config_log records for chunk");
-
-                            // Check if we've exceeded the maximum execution time.
-                            if (time() >= $starttime + self::MAX_EXECUTION_TIME) {
-                                mtrace("... Reached time limit. Processed {$totaldeleted} records so far.");
-                                $hasmore = true;
-                                break 2; // Break out of both foreach loops.
-                            }
-
-                            // Brief pause to allow locks to be released and other queries to execute.
-                            usleep(100000); // 0.1 seconds.
                         }
+
+                        // Delete config_log records for this chunk, whether or not matching
+                        // logstore_standard_log records were found. Those log records are routinely
+                        // removed by \logstore_standard\task\cleanup_task (loglifetime setting), while
+                        // config_log is never purged by Moodle, so a match is not guaranteed.
+                        $DB->delete_records_list('config_log', 'id', $chunk);
+                        mtrace("... Deleted " . count($chunk) . " config_log records for chunk");
+
+                        // Check if we've exceeded the maximum execution time.
+                        if (time() >= $starttime + self::MAX_EXECUTION_TIME) {
+                            mtrace("... Reached time limit. Processed {$totaldeleted} records so far.");
+                            $hasmore = true;
+                            break 2; // Break out of both foreach loops.
+                        }
+
+                        // Brief pause to allow locks to be released and other queries to execute.
+                        usleep(100000); // 0.1 seconds.
                     }
 
                     // Check if there are more records to process for this config name.

--- a/local/o365/classes/task/deleteinvalidconfiglog.php
+++ b/local/o365/classes/task/deleteinvalidconfiglog.php
@@ -186,6 +186,7 @@ class deleteinvalidconfiglog extends adhoc_task {
                         // removed by \logstore_standard\task\cleanup_task (loglifetime setting), while
                         // config_log is never purged by Moodle, so a match is not guaranteed.
                         $DB->delete_records_list('config_log', 'id', $chunk);
+                        $totaldeleted += count($chunk);
                         mtrace("... Deleted " . count($chunk) . " config_log records for chunk");
 
                         // Check if we've exceeded the maximum execution time.


### PR DESCRIPTION
Fix local_o365 adhoc task deleting config_log records only when a matching logstore_standard_log row exists, causing infinite requeueing