### PR TITLE
Hide secret expiry notification heading when its only setting is hidden

### DIFF
--- a/auth/oidc/classes/adminsetting/auth_oidc_admin_setting_section_heading.php
+++ b/auth/oidc/classes/adminsetting/auth_oidc_admin_setting_section_heading.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definition of a section heading admin setting that can be hidden with hide_if().
+ *
+ * @package auth_oidc
+ * @author Lai Wei <lai.wei@enovation.ie>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2021 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace auth_oidc\adminsetting;
+
+use admin_setting_heading;
+use html_writer;
+
+/**
+ * A section heading that participates in admin settings hide_if() dependencies.
+ *
+ * The core {@see admin_setting_heading} renders only a bare <h3>, with no named
+ * form control and no .form-item wrapper, so the admin settings show/hide
+ * JavaScript (lib/amd/src/showhidesettings.js) cannot target it and any
+ * hide_if() condition applied to it is silently ignored. This subclass wraps the
+ * heading in a .form-item container and adds a hidden input carrying the
+ * setting's form field name, so the heading is shown and hidden together with
+ * the settings it introduces.
+ */
+class auth_oidc_admin_setting_section_heading extends admin_setting_heading {
+    /**
+     * Output the heading wrapped so that hide_if() dependencies can act on it.
+     *
+     * @param mixed $data
+     * @param string $query
+     * @return string
+     */
+    public function output_html($data, $query = '') {
+        $heading = parent::output_html($data, $query);
+        $hiddeninput = html_writer::empty_tag('input', [
+            'type' => 'hidden',
+            'name' => 's_' . $this->plugin . '_' . $this->name,
+            'value' => 1,
+        ]);
+
+        return html_writer::div($hiddeninput . $heading, 'form-item', ['id' => 'admin-' . $this->name]);
+    }
+}

--- a/auth/oidc/settings.php
+++ b/auth/oidc/settings.php
@@ -384,6 +384,21 @@ if ($hassiteconfig) {
             'eq',
             AUTH_OIDC_IDP_TYPE_OTHER
         );
+
+        // Hide the section heading too, so an empty section isn't shown when the only
+        // setting in it is hidden.
+        $applicationsettings->hide_if(
+            'auth_oidc/application_secretexpiry_heading',
+            'auth_oidc/clientauthmethod',
+            'neq',
+            AUTH_OIDC_AUTH_METHOD_SECRET
+        );
+        $applicationsettings->hide_if(
+            'auth_oidc/application_secretexpiry_heading',
+            'auth_oidc/idptype',
+            'eq',
+            AUTH_OIDC_IDP_TYPE_OTHER
+        );
     }
 
     $ADMIN->add('oidcfolder', $applicationsettings);

--- a/auth/oidc/settings.php
+++ b/auth/oidc/settings.php
@@ -30,6 +30,7 @@ use auth_oidc\adminsetting\auth_oidc_admin_setting_endpoint;
 use auth_oidc\adminsetting\auth_oidc_admin_setting_iconselect;
 use auth_oidc\adminsetting\auth_oidc_admin_setting_loginflow;
 use auth_oidc\adminsetting\auth_oidc_admin_setting_redirecturi;
+use auth_oidc\adminsetting\auth_oidc_admin_setting_section_heading;
 use auth_oidc\utils;
 use core\url;
 
@@ -281,7 +282,7 @@ if ($hassiteconfig) {
 
     // Secret expiry notification (only when local_o365 is installed).
     if (auth_oidc_is_local_365_installed()) {
-        $applicationsettings->add(new admin_setting_heading(
+        $applicationsettings->add(new auth_oidc_admin_setting_section_heading(
             'auth_oidc/application_secretexpiry_heading',
             get_string('settings_section_secret_expiry_notification', 'auth_oidc'),
             ''


### PR DESCRIPTION
The "Secret expiry notification" section heading was always shown once local_o365 is installed, even when its only field (secret expiry recipients) is JS-hidden because the client authentication method isn't Secret or the IdP type is Other. This left an empty section with just a heading and the page's Save button above it. Apply the same hide_if() conditions to the heading so it hides together with the field it introduces.