### PR TITLE
Fix warning message display for giving admin consent using Microsoft v2 IdP

### DIFF
--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -396,9 +396,33 @@ class authcode extends base {
         $SESSION->stateadditionaldata = $additionaldata;
         $DB->delete_records('auth_oidc_state', ['id' => $staterec->id]);
 
-        // Get token.
+        // Re-associate the browser session with the admin who initiated the consent request before doing
+        // anything that might fail below, so a failure in the auto-detection step (see below) does not leave
+        // the admin looking logged out on the resulting page.
+        if ($csrfverified && !empty($additionaldata['initiatinguserid'])) {
+            $initiatinguser = core_user::get_user((int) $additionaldata['initiatinguserid']);
+            if (
+                $initiatinguser && empty($initiatinguser->deleted) &&
+                (!isloggedin() || isguestuser())
+            ) {
+                \core\session\manager::login_user($initiatinguser);
+            }
+        }
+
+        // Get token. This app-only token is only used to auto-detect the Microsoft Entra tenant and OneDrive for
+        // Business URL settings below; admin consent itself has already been granted by Microsoft Entra by this
+        // point. Conditional Access policies can block this specific app-only token request (AADSTS53003) even
+        // though consent succeeded, and the tenant/URL can still be auto-detected via other Graph API calls, so
+        // that failure is not fatal and is silently redirected past.
         $client = $this->get_oidcclient();
-        $tokenparams = $client->app_access_token_request();
+        try {
+            $tokenparams = $client->app_access_token_request();
+        } catch (moodle_exception $e) {
+            if ($e->errorcode === 'settings_adminconsent_error_53003' && $e->module === 'local_o365') {
+                redirect($e->link);
+            }
+            throw $e;
+        }
         if (!isset($tokenparams['access_token'])) {
             throw new moodle_exception('errorauthnoaccesstoken', 'auth_oidc');
         }
@@ -412,16 +436,6 @@ class authcode extends base {
         ];
         $event = user_authed::create($eventdata);
         $event->trigger();
-
-        if ($csrfverified && !empty($additionaldata['initiatinguserid'])) {
-            $initiatinguser = core_user::get_user((int) $additionaldata['initiatinguserid']);
-            if (
-                $initiatinguser && empty($initiatinguser->deleted) &&
-                (!isloggedin() || isguestuser())
-            ) {
-                \core\session\manager::login_user($initiatinguser);
-            }
-        }
 
         $redirect = (!empty($additionaldata['redirect'])) ? $additionaldata['redirect'] : '/auth/oidc/ucp.php';
         redirect(new url($redirect));

--- a/local/o365/lang/en/local_o365.php
+++ b/local/o365/lang/en/local_o365.php
@@ -59,7 +59,6 @@ $string['settings_setup_step3_desc'] = 'Setup is complete. Click the "Update" bu
 // Settings in "Step 2/2" section of the "Setup" tab.
 $string['settings_adminconsent'] = 'Admin Consent';
 $string['settings_adminconsent_btn'] = 'Provide Admin Consent';
-$string['settings_adminconsent_error_53003'] = 'A known issue has happened when providing admin consent, which only applies to Microsoft identity platform (v2.0) IdP type. As a result, the integration cannot detect Microsoft Entra tenant and OneDrive for Business URL settings below automatically. Please set these values manually.';
 $string['settings_adminconsent_details'] = 'To allow access to some of the permissions needed, an administrator will need to provide admin consent. Click this button, then log in with a Microsoft Entra ID administrator account to provide consent. This will need to be done whenever you change "Admin" permissions in Entra ID.';
 $string['settings_entratenant'] = 'Microsoft Entra tenant';
 $string['settings_entratenant_details'] = 'Used to Identify your organization within Microsoft. For example: "contoso.onmicrosoft.com".<br/>


### PR DESCRIPTION
When the auth_oidc plugin is configured to use Microsoft identity platform (v2) IdP, the "Microsoft Entra tenant" and "OneDrive for Business URL" settings need to be manual filled after providing admin consent. The local_o365 plugin settings page displays a message about it, but this is invisible unless debugging is turned on. This commit changes how the message is displayed so it's more obvious.