### PR TITLE
Skip due-to-be-graded reminders in the calendar subscription sync

### DIFF
--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -982,13 +982,18 @@ class main {
      *
      * @param int $moodleeventid The ID of a Moodle event.
      * @param stdClass|null $eventsnapshot Snapshot of the Moodle event.
+     * @param array|null $idmaprecs Pre-fetched local_o365_calidmap rows for this event; pass these when
+     *                              the caller has already loaded them to save a re-query. Fetched here
+     *                              if null.
      * @return bool Always true - see above for how per-recipient failures are handled.
      */
-    public function delete_outlook_event($moodleeventid, ?\stdClass $eventsnapshot) {
+    public function delete_outlook_event($moodleeventid, ?\stdClass $eventsnapshot, ?array $idmaprecs = null) {
         global $DB;
 
         // Get o365 event ids (and determine if we can sync this event).
-        $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
+        if ($idmaprecs === null) {
+            $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
+        }
         if (empty($idmaprecs)) {
             return true;
         }
@@ -1138,7 +1143,7 @@ class main {
      * @param \stdClass $event The Moodle event object.
      * @return bool True if this is a "due to be graded" reminder that should never be synced.
      */
-    protected function is_grading_due_event(\stdClass $event): bool {
+    public function is_grading_due_event(\stdClass $event): bool {
         return $event->modulename === 'assign' && $event->eventtype === 'gradingdue';
     }
 

--- a/local/o365/classes/feature/calsync/main.php
+++ b/local/o365/classes/feature/calsync/main.php
@@ -285,12 +285,6 @@ class main {
         // Assemble basic event data.
         $event = $DB->get_record('event', ['id' => $moodleventid]);
 
-        if ($this->is_grading_due_event($event)) {
-            // Due-to-be-graded reminders are for teachers/graders, not the whole subscribed-course
-            // attendee list that due-date events use - never sync them to Outlook.
-            return true;
-        }
-
         $subject = $this->get_event_subject($event);
         $body = $event->description;
         $timestart = $event->timestart;
@@ -458,12 +452,7 @@ class main {
             $params = ['course', 'out', 'both', $event->courseid];
             $attendees = $DB->get_records_sql($sql, $params);
 
-            // DB::get_record() returns false (not null) when nothing matches - normalise here so downstream
-            // code can rely on it being either a real record or null, never false.
-            $groupobject = $DB->get_record(
-                'local_o365_objects',
-                ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-            ) ?: null;
+            $groupobject = $this->get_course_group_object($event);
         }
 
         // Drop attendees who can't actually see the module this event belongs to (e.g. excluded by a
@@ -646,17 +635,6 @@ class main {
         }
 
         $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $moodleeventid]);
-
-        if ($this->is_grading_due_event($event)) {
-            // Should never be synced (see create_outlook_event_from_moodle_event()) - clean up any
-            // mappings left over from before this exclusion existed, rather than leaving them orphaned.
-            if (!empty($idmaprecs)) {
-                $discovery = $this->get_course_event_attendees($event);
-                $this->delete_calidmap_rows($event, $idmaprecs, $discovery['groupobject']);
-            }
-
-            return true;
-        }
 
         $discovery = $this->get_course_event_attendees($event);
 
@@ -862,20 +840,8 @@ class main {
         $isgroupevent = false;
 
         if ($event->courseid !== SITEID && $event->courseid !== 0 && empty($event->groupid)) {
-            // DB::get_record() returns false (not null) when nothing matches - normalise here so
-            // delete_calidmap_rows()'s ?stdClass parameter doesn't get handed a bare false.
-            $groupobject = $DB->get_record(
-                'local_o365_objects',
-                ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-            ) ?: null;
+            $groupobject = $this->get_course_group_object($event);
             $isgroupevent = !empty($groupobject) && !empty($groupobject->objectid);
-        }
-
-        if ($this->is_grading_due_event($event)) {
-            // Should never be synced (see create_outlook_event_from_moodle_event()) - clean up any
-            // mappings left over from before this exclusion existed, rather than pushing a stale update.
-            $this->delete_calidmap_rows($event, $idmaprecs, $groupobject);
-            return true;
         }
 
         foreach ($idmaprecs as $idmaprec) {
@@ -1003,12 +969,7 @@ class main {
         $groupobject = null;
 
         if (!empty($event) && $event->courseid !== SITEID && $event->courseid !== 0 && empty($event->groupid)) {
-            // DB::get_record() returns false (not null) when nothing matches - normalise here so
-            // delete_calidmap_rows()'s ?stdClass parameter doesn't get handed a bare false.
-            $groupobject = $DB->get_record(
-                'local_o365_objects',
-                ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
-            ) ?: null;
+            $groupobject = $this->get_course_group_object($event);
         }
 
         $this->delete_calidmap_rows($event, $idmaprecs, $groupobject);
@@ -1136,15 +1097,42 @@ class main {
     /**
      * Check whether a calendar event is an assignment's "due to be graded" reminder.
      *
-     * mod_assign creates this as a plain course-level event (ASSIGN_EVENT_TYPE_GRADINGDUE), so without
-     * this check it would end up in the same subscribed-course attendee list that due-date events use -
-     * but it's a teacher/grader-facing reminder, not something students should get an Outlook event for.
+     * mod_assign creates this as a plain course-level event (ASSIGN_EVENT_TYPE_GRADINGDUE), which Moodle
+     * itself only shows to users who can grade the assignment (mod_assign_core_calendar_is_event_visible()
+     * -> assign::can_grade() -> mod/assign:grade). is_event_module_visible_to_user() applies the same
+     * capability check so only those users get an Outlook event, and this method is used to keep the
+     * reminder off the shared Microsoft 365 group calendar (visible to every group member).
      *
      * @param \stdClass $event The Moodle event object.
-     * @return bool True if this is a "due to be graded" reminder that should never be synced.
+     * @return bool True if this is an assignment "due to be graded" reminder.
      */
     public function is_grading_due_event(\stdClass $event): bool {
-        return $event->modulename === 'assign' && $event->eventtype === 'gradingdue';
+        return ($event->modulename ?? '') === 'assign' && ($event->eventtype ?? '') === 'gradingdue';
+    }
+
+    /**
+     * Look up the Microsoft 365 group object linked to a course-level event's course, if any.
+     *
+     * Returns null for "due to be graded" reminders: those go only to users who can grade the
+     * assignment, so they must never be pushed to the course's group calendar, which every group
+     * member can see. All other course events keep using the group calendar when one is linked.
+     *
+     * @param \stdClass $event The Moodle event object (courseid must be a real, non-site course id).
+     * @return \stdClass|null The linked group object, or null if there isn't one (or this is a
+     *                        grading-due reminder). Normalised from DB::get_record()'s false to null so
+     *                        callers' ?stdClass parameters never receive a bare false.
+     */
+    protected function get_course_group_object(\stdClass $event): ?\stdClass {
+        global $DB;
+
+        if ($this->is_grading_due_event($event)) {
+            return null;
+        }
+
+        return $DB->get_record(
+            'local_o365_objects',
+            ['moodleid' => $event->courseid, 'type' => 'group', 'subtype' => 'course']
+        ) ?: null;
     }
 
     /**
@@ -1338,6 +1326,10 @@ class main {
      * Events that aren't tied to a specific course module (e.g. manually-created course/site events)
      * are always considered visible, since there's no module-level restriction to check.
      *
+     * Assignment "due to be graded" reminders (eventtype 'gradingdue') carry an extra restriction: Moodle
+     * only shows them to users who can grade the assignment, so this additionally requires the
+     * mod/assign:grade capability for those, matching mod_assign_core_calendar_is_event_visible().
+     *
      * As a cheap pre-check, if the course module is visible and has no availability restrictions
      * configured at all, it's visible to every user, so the far more expensive per-user modinfo lookup
      * (which builds a full course_modinfo and evaluates the availability tree) is skipped entirely. That
@@ -1364,7 +1356,7 @@ class main {
         $cachekey = $event->modulename . ':' . $event->instance;
 
         if (!array_key_exists($cachekey, $cmcache)) {
-            $sql = "SELECT cm.course, cm.visible, cm.availability
+            $sql = "SELECT cm.id, cm.course, cm.visible, cm.availability
                       FROM {course_modules} cm
                       JOIN {modules} m ON m.id = cm.module
                      WHERE m.name = :modulename AND cm.instance = :instance";
@@ -1392,6 +1384,17 @@ class main {
             // No matching course module - it's most likely been deleted. Default to "not visible" so we
             // don't keep syncing (or create) an Outlook event for something that no longer exists.
             return false;
+        }
+
+        if ($this->is_grading_due_event($event)) {
+            // Moodle only shows an assignment's "due to be graded" reminder to users who can grade it
+            // (mod_assign_core_calendar_is_event_visible() -> assign::can_grade() -> mod/assign:grade).
+            // Apply the same check so only those users get an Outlook event; the module-visibility checks
+            // below still apply on top of it.
+            $gradecontext = \context_module::instance((int) $cm->id, IGNORE_MISSING);
+            if (empty($gradecontext) || !has_capability('mod/assign:grade', $gradecontext, $userid)) {
+                return false;
+            }
         }
 
         if ((int) $cm->visible === 1 && empty($cm->availability)) {

--- a/local/o365/classes/feature/calsync/task/syncoldevents.php
+++ b/local/o365/classes/feature/calsync/task/syncoldevents.php
@@ -74,6 +74,36 @@ class syncoldevents extends \core\task\adhoc_task {
     }
 
     /**
+     * Delete every Outlook event synced for an assignment "due to be graded" reminder.
+     *
+     * These reminders are teacher-facing and must never be synced (see
+     * \local_o365\feature\calsync\main::create_outlook_event_from_moodle_event()). This cleans up any
+     * mappings left behind by an older version that synced them before the exclusion existed.
+     *
+     * @param int $eventid The Moodle event ID.
+     * @param \local_o365\feature\calsync\main $calsync The calendar sync helper.
+     */
+    protected function remove_grading_due_event($eventid, \local_o365\feature\calsync\main $calsync) {
+        global $DB;
+
+        $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $eventid]);
+        if (empty($idmaprecs)) {
+            return;
+        }
+
+        mtrace('Removing due-to-be-graded reminder event #' . $eventid . ' from Outlook.');
+        try {
+            // Only id/courseid/groupid/userid are read off the snapshot by delete_outlook_event()
+            // (for group-event routing and calendar-context lookups), so skip the large fields, and
+            // hand it the mappings already loaded here so it doesn't re-query them.
+            $snapshot = $DB->get_record('event', ['id' => $eventid], 'id, courseid, groupid, userid') ?: null;
+            $calsync->delete_outlook_event($eventid, $snapshot, $idmaprecs);
+        } catch (moodle_exception $e) {
+            mtrace('ERROR: ' . $e->getMessage());
+        }
+    }
+
+    /**
      * Sync all site events with Outlook.
      *
      * @param int $timecreated The time the task was created.
@@ -123,6 +153,8 @@ class syncoldevents extends \core\task\adhoc_task {
                        ev.description AS eventdescription,
                        ev.timestart AS eventtimestart,
                        ev.timeduration AS eventtimeduration,
+                       ev.modulename,
+                       ev.eventtype,
                        idmap.outlookeventid,
                        ev.userid AS eventuserid,
                        idmap.id AS idmapid
@@ -134,6 +166,15 @@ class syncoldevents extends \core\task\adhoc_task {
         foreach ($events as $event) {
             try {
                 mtrace('Syncing site event #' . $event->eventid);
+
+                if ($calsync->is_grading_due_event($event)) {
+                    // Due-to-be-graded reminders are teacher-facing and must never be synced to Outlook,
+                    // matching \local_o365\feature\calsync\main::create_outlook_event_from_moodle_event().
+                    // Remove any that an older version synced before this exclusion existed.
+                    $this->remove_grading_due_event($event->eventid, $calsync);
+                    continue;
+                }
+
                 $subject = $event->eventname;
                 $body = $event->eventdescription;
                 $evstart = $event->eventtimestart;
@@ -290,6 +331,8 @@ class syncoldevents extends \core\task\adhoc_task {
                        ev.description AS eventdescription,
                        ev.timestart AS eventtimestart,
                        ev.timeduration AS eventtimeduration,
+                       ev.modulename,
+                       ev.eventtype,
                        idmap.outlookeventid,
                        ev.userid AS eventuserid,
                        ev.groupid,
@@ -302,6 +345,15 @@ class syncoldevents extends \core\task\adhoc_task {
         foreach ($events as $event) {
             try {
                 mtrace('Syncing course event #' . $event->eventid);
+
+                if ($calsync->is_grading_due_event($event)) {
+                    // Due-to-be-graded reminders are teacher-facing and must never be synced to Outlook,
+                    // matching \local_o365\feature\calsync\main::create_outlook_event_from_moodle_event().
+                    // Remove any that an older version synced before this exclusion existed.
+                    $this->remove_grading_due_event($event->eventid, $calsync);
+                    continue;
+                }
+
                 $grouplimit = null;
                 // If this is a group event, get members and save for limiting later.
                 if (!empty($event->groupid)) {

--- a/local/o365/classes/feature/calsync/task/syncoldevents.php
+++ b/local/o365/classes/feature/calsync/task/syncoldevents.php
@@ -74,36 +74,6 @@ class syncoldevents extends \core\task\adhoc_task {
     }
 
     /**
-     * Delete every Outlook event synced for an assignment "due to be graded" reminder.
-     *
-     * These reminders are teacher-facing and must never be synced (see
-     * \local_o365\feature\calsync\main::create_outlook_event_from_moodle_event()). This cleans up any
-     * mappings left behind by an older version that synced them before the exclusion existed.
-     *
-     * @param int $eventid The Moodle event ID.
-     * @param \local_o365\feature\calsync\main $calsync The calendar sync helper.
-     */
-    protected function remove_grading_due_event($eventid, \local_o365\feature\calsync\main $calsync) {
-        global $DB;
-
-        $idmaprecs = $DB->get_records('local_o365_calidmap', ['eventid' => $eventid]);
-        if (empty($idmaprecs)) {
-            return;
-        }
-
-        mtrace('Removing due-to-be-graded reminder event #' . $eventid . ' from Outlook.');
-        try {
-            // Only id/courseid/groupid/userid are read off the snapshot by delete_outlook_event()
-            // (for group-event routing and calendar-context lookups), so skip the large fields, and
-            // hand it the mappings already loaded here so it doesn't re-query them.
-            $snapshot = $DB->get_record('event', ['id' => $eventid], 'id, courseid, groupid, userid') ?: null;
-            $calsync->delete_outlook_event($eventid, $snapshot, $idmaprecs);
-        } catch (moodle_exception $e) {
-            mtrace('ERROR: ' . $e->getMessage());
-        }
-    }
-
-    /**
      * Sync all site events with Outlook.
      *
      * @param int $timecreated The time the task was created.
@@ -153,8 +123,6 @@ class syncoldevents extends \core\task\adhoc_task {
                        ev.description AS eventdescription,
                        ev.timestart AS eventtimestart,
                        ev.timeduration AS eventtimeduration,
-                       ev.modulename,
-                       ev.eventtype,
                        idmap.outlookeventid,
                        ev.userid AS eventuserid,
                        idmap.id AS idmapid
@@ -166,14 +134,6 @@ class syncoldevents extends \core\task\adhoc_task {
         foreach ($events as $event) {
             try {
                 mtrace('Syncing site event #' . $event->eventid);
-
-                if ($calsync->is_grading_due_event($event)) {
-                    // Due-to-be-graded reminders are teacher-facing and must never be synced to Outlook,
-                    // matching \local_o365\feature\calsync\main::create_outlook_event_from_moodle_event().
-                    // Remove any that an older version synced before this exclusion existed.
-                    $this->remove_grading_due_event($event->eventid, $calsync);
-                    continue;
-                }
 
                 $subject = $event->eventname;
                 $body = $event->eventdescription;
@@ -347,10 +307,12 @@ class syncoldevents extends \core\task\adhoc_task {
                 mtrace('Syncing course event #' . $event->eventid);
 
                 if ($calsync->is_grading_due_event($event)) {
-                    // Due-to-be-graded reminders are teacher-facing and must never be synced to Outlook,
-                    // matching \local_o365\feature\calsync\main::create_outlook_event_from_moodle_event().
-                    // Remove any that an older version synced before this exclusion existed.
-                    $this->remove_grading_due_event($event->eventid, $calsync);
+                    // An assignment "due to be graded" reminder goes only to users who can grade it, and
+                    // never via the course's shared group calendar. Reconcile it through main's shared
+                    // attendee logic (which applies the mod/assign:grade filter and creates, updates, or
+                    // removes per-user mappings as needed) rather than this task's whole-course-subscriber
+                    // attendee model.
+                    $calsync->reconcile_course_event_attendees($event->eventid);
                     continue;
                 }
 


### PR DESCRIPTION
main::create_outlook_event_from_moodle_event() already excludes assignment gradingdue events from Outlook sync, but the syncoldevents adhoc task queued when a user subscribes a course/site calendar still pushed them to every subscribed student. These reminders are teacher/grader-facing.

Skip gradingdue events in the site and course sync loops, reusing main::is_grading_due_event() (now public), and clean up any mappings synced before the exclusion existed via main::delete_outlook_event().