### PR TITLE
Bump actions/checkout from 6.1.0 to 7.0.1 in all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Check out sub repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # matrix.internal-deps is space-separated and cannot be a single
           # sparse pattern, so check out every folder that is a dependency of

--- a/auth/oidc/.github/workflows/ci.yml
+++ b/auth/oidc/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/blocks/microsoft/.github/workflows/ci.yml
+++ b/blocks/microsoft/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/lib/editor/atto/plugins/teamsmeeting/.github/workflows/ci.yml
+++ b/lib/editor/atto/plugins/teamsmeeting/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/lib/editor/tiny/plugins/teamsmeeting/.github/workflows/ci.yml
+++ b/lib/editor/tiny/plugins/teamsmeeting/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/local/o365/.github/workflows/ci.yml
+++ b/local/o365/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/local/office365/.github/workflows/ci.yml
+++ b/local/office365/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/local/onenote/.github/workflows/ci.yml
+++ b/local/onenote/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/mod/assign/feedback/onenote/.github/workflows/ci.yml
+++ b/mod/assign/feedback/onenote/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/mod/assign/submission/onenote/.github/workflows/ci.yml
+++ b/mod/assign/submission/onenote/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/repository/office365/.github/workflows/ci.yml
+++ b/repository/office365/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 

--- a/theme/boost_o365teams/.github/workflows/ci.yml
+++ b/theme/boost_o365teams/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: plugin
 


### PR DESCRIPTION
Applies the dependabot update from microsoft/o365-moodle#3465 to the root workflow and every plugin-level .github/workflows/ci.yml.