### PR TITLE
local_o365: defer settings.php Graph API calls to render time

### DIFF
--- a/local/o365/classes/adminsetting/moodleappid.php
+++ b/local/o365/classes/adminsetting/moodleappid.php
@@ -1,0 +1,98 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Admin setting for the Moodle app ID in the Teams app catalog.
+ *
+ * @package local_o365
+ * @author Lai Wei <lai.wei@enovation.ie>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\adminsetting;
+
+use admin_setting_configtext;
+use moodle_exception;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/lib/adminlib.php');
+require_once($CFG->dirroot . '/local/o365/lib.php');
+
+/**
+ * Config text for the Moodle app ID, appending the auto-detected catalog app ID to the description when rendered.
+ *
+ * The Graph API is only queried when the setting is rendered, so building the full admin tree
+ * (for example on /admin/search.php) does not trigger a Graph API call.
+ */
+class moodleappid extends admin_setting_configtext {
+    /**
+     * Return the XHTML for this setting, with the auto-detected catalog app ID appended to the description.
+     *
+     * @param mixed $data
+     * @param string $query
+     * @return string
+     */
+    public function output_html($data, $query = '') {
+        $originaldescription = $this->description;
+        $this->description .= $this->get_auto_id_description();
+        $html = parent::output_html($data, $query);
+        $this->description = $originaldescription;
+
+        return $html;
+    }
+
+    /**
+     * Query the Graph API for the catalog app ID and return the description snippet to append, or an empty string.
+     *
+     * @return string
+     */
+    protected function get_auto_id_description(): string {
+        if (\local_o365\utils::is_connected() !== true) {
+            return '';
+        }
+
+        try {
+            $graphclient = \local_o365\utils::get_api();
+        } catch (moodle_exception $e) {
+            return '';
+        }
+        if (!$graphclient) {
+            return '';
+        }
+
+        $teamsmoodleappexternalid = get_config('local_o365', 'teams_moodle_app_external_id');
+        if (!$teamsmoodleappexternalid) {
+            $teamsmoodleappexternalid = TEAMS_MOODLE_APP_EXTERNAL_ID;
+        }
+
+        try {
+            $moodleappid = $graphclient->get_catalog_app_id($teamsmoodleappexternalid);
+        } catch (moodle_exception $e) {
+            debugging('Error getting catalog app ID. Details: ' . $e->getMessage(), DEBUG_NORMAL);
+            return '';
+        }
+
+        if (!$moodleappid) {
+            return '';
+        }
+
+        return get_string('settings_moodle_app_id_desc_auto_id', 'local_o365', $moodleappid);
+    }
+}

--- a/local/o365/classes/adminsetting/sdsprofilesync.php
+++ b/local/o365/classes/adminsetting/sdsprofilesync.php
@@ -1,0 +1,123 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Admin setting for the SDS profile sync school selector.
+ *
+ * @package local_o365
+ * @author Lai Wei <lai.wei@enovation.ie>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\adminsetting;
+
+use admin_setting_configselect;
+use core_text;
+use lang_string;
+use local_o365\feature\sds\utils;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/lib/adminlib.php');
+
+/**
+ * Select of SDS schools for profile sync, with the school list loaded lazily from the Graph API.
+ *
+ * The choices are only fetched when the setting is actually rendered, so building the full admin tree
+ * (for example on /admin/search.php) does not trigger a Graph API call.
+ */
+class sdsprofilesync extends admin_setting_configselect {
+    /**
+     * Populate the list of choices on demand.
+     *
+     * Always fills $this->choices: the full school list from the Graph API when it can be retrieved, otherwise just
+     * "Disabled" plus the currently stored school, so the form still reflects the effective configuration.
+     *
+     * @return bool always true
+     */
+    public function load_choices() {
+        if (is_array($this->choices)) {
+            return true;
+        }
+
+        $this->choices = ['' => new lang_string('settings_sds_profilesync_disabled', 'local_o365')];
+
+        [$status, $schools] = utils::get_settings_schools();
+        if ($status !== 'ok') {
+            // The school list is unavailable. Keep the currently stored school as a choice so the form reflects the
+            // effective configuration instead of falling back to display the first ("Disabled") option.
+            $current = $this->get_setting();
+            if (!empty($current)) {
+                $this->choices[$current] = get_string('settings_sds_school_unavailable', 'local_o365', $current);
+            }
+
+            return true;
+        }
+
+        $schoolchoices = [];
+        foreach ($schools as $schoolid => $schoolname) {
+            $schoolchoices[$schoolid] = $schoolname . ' (' . $schoolid . ')';
+        }
+        asort($schoolchoices);
+        $this->choices += $schoolchoices;
+
+        return true;
+    }
+
+    /**
+     * Save the submitted value, unless the school list could not be retrieved.
+     *
+     * When the Graph API is unavailable the school choices are not authoritative, so leave a previously configured
+     * school untouched rather than risk clearing it from a stale form submission.
+     *
+     * @param string $data
+     * @return string empty string on success, error message otherwise
+     */
+    public function write_setting($data) {
+        [$status] = utils::get_settings_schools();
+        if ($status !== 'ok') {
+            return '';
+        }
+
+        return parent::write_setting($data);
+    }
+
+    /**
+     * Is this setting related to the given query text.
+     *
+     * Deliberately matches only on the static name, visible name and description so that searching the admin settings
+     * does not load the school list from the Graph API.
+     *
+     * @param string $query
+     * @return bool true if related, false if not
+     */
+    public function is_related($query) {
+        if (strpos(strtolower($this->name), $query) !== false) {
+            return true;
+        }
+        if (strpos(core_text::strtolower($this->visiblename), $query) !== false) {
+            return true;
+        }
+        if (strpos(core_text::strtolower($this->description), $query) !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/local/o365/classes/adminsetting/sdsschools.php
+++ b/local/o365/classes/adminsetting/sdsschools.php
@@ -1,0 +1,105 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Admin setting for the SDS course sync school selector.
+ *
+ * @package local_o365
+ * @author Lai Wei <lai.wei@enovation.ie>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\adminsetting;
+
+use admin_setting_configmulticheckbox;
+use core_text;
+use local_o365\feature\sds\utils;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/lib/adminlib.php');
+
+/**
+ * Multi checkbox of SDS schools, with the school list loaded lazily from the Graph API.
+ *
+ * The choices are only fetched when the setting is actually rendered, so building the full admin tree
+ * (for example on /admin/search.php) does not trigger a Graph API call.
+ */
+class sdsschools extends admin_setting_configmulticheckbox {
+    /**
+     * Load the list of schools from the Graph API on demand.
+     *
+     * Returns false when the list cannot be retrieved: the parent renderer then suppresses the checkbox list (rather
+     * than showing an empty one) and the sdsschoolsstatus heading explains why. write_setting() also relies on this to
+     * leave a previously configured school list untouched, so a transient failure does not silently disable course sync.
+     *
+     * @return bool true if the school list was retrieved, false otherwise
+     */
+    public function load_choices() {
+        if (is_array($this->choices)) {
+            return true;
+        }
+
+        [$status, $schools] = utils::get_settings_schools();
+        if ($status !== 'ok') {
+            return false;
+        }
+
+        $this->choices = $schools;
+
+        return true;
+    }
+
+    /**
+     * Save the submitted value, unless the school list could not be retrieved.
+     *
+     * @param array $data
+     * @return string empty string on success, error message otherwise
+     */
+    public function write_setting($data) {
+        if (!$this->load_choices()) {
+            return '';
+        }
+
+        return parent::write_setting($data);
+    }
+
+    /**
+     * Is this setting related to the given query text.
+     *
+     * Deliberately matches only on the static name, visible name and description so that searching the admin settings
+     * does not load the school list from the Graph API.
+     *
+     * @param string $query
+     * @return bool true if related, false if not
+     */
+    public function is_related($query) {
+        if (strpos(strtolower($this->name), $query) !== false) {
+            return true;
+        }
+        if (strpos(core_text::strtolower($this->visiblename), $query) !== false) {
+            return true;
+        }
+        if (strpos(core_text::strtolower($this->description), $query) !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/local/o365/classes/adminsetting/sdsschoolsstatus.php
+++ b/local/o365/classes/adminsetting/sdsschoolsstatus.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Informational heading reporting the SDS school list retrieval status.
+ *
+ * @package local_o365
+ * @author Lai Wei <lai.wei@enovation.ie>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace local_o365\adminsetting;
+
+use admin_setting_heading;
+use html_writer;
+use local_o365\feature\sds\utils;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/lib/adminlib.php');
+
+/**
+ * Heading that shows a message when the SDS school list cannot be retrieved.
+ *
+ * The Graph API is only queried when the heading is rendered, so building the full admin tree
+ * (for example on /admin/search.php) does not trigger a Graph API call.
+ */
+class sdsschoolsstatus extends admin_setting_heading {
+    /**
+     * Constructor.
+     *
+     * @param string $name unique ascii name
+     */
+    public function __construct($name) {
+        parent::__construct($name, '', '');
+    }
+
+    /**
+     * Return the HTML for this heading, or an empty string when the school list was retrieved successfully.
+     *
+     * @param mixed $data
+     * @param string $query
+     * @return string
+     */
+    public function output_html($data, $query = '') {
+        $message = $this->get_status_message();
+        if ($message === '') {
+            return '';
+        }
+
+        // Set the description only for this render and restore it afterwards, so the transient message does not leak
+        // into a later render or into is_related().
+        $original = $this->description;
+        $this->description = $message;
+        $html = parent::output_html($data, $query);
+        $this->description = $original;
+
+        return $html;
+    }
+
+    /**
+     * This heading is not a real setting and must never appear in the admin settings search results.
+     *
+     * @param string $query
+     * @return bool always false
+     */
+    public function is_related($query) {
+        return false;
+    }
+
+    /**
+     * Return the message to show for the current SDS school list retrieval status, or an empty string when it succeeded.
+     *
+     * @return string
+     */
+    protected function get_status_message(): string {
+        [$status] = utils::get_settings_schools();
+
+        switch ($status) {
+            case 'noschools':
+                return get_string('settings_sds_noschools', 'local_o365');
+            case 'notconnected':
+                return html_writer::div(get_string('error_not_connected', 'local_o365'), 'alert alert-info');
+            case 'ok':
+                return '';
+            default:
+                // Status 'error' - the school list could not be retrieved.
+                return get_string('settings_sds_get_schools_error', 'local_o365');
+        }
+    }
+}

--- a/local/o365/classes/feature/sds/utils.php
+++ b/local/o365/classes/feature/sds/utils.php
@@ -66,6 +66,51 @@ class utils {
     }
 
     /**
+     * Return the list of SDS schools for use on the plugin settings page.
+     *
+     * The result is cached for the duration of the request, so the Graph API is called at most once no matter how many
+     * settings rely on it. This lets the settings page defer the Graph API call until the SDS page is actually rendered,
+     * rather than every time the full admin tree is built (for example on /admin/search.php).
+     *
+     * @return array [$status, $schools] where $status is one of 'ok', 'notconnected', 'noschools' or 'error', and
+     *               $schools is an array of [schoolid => displayname, ...] (empty unless $status is 'ok').
+     */
+    public static function get_settings_schools(): array {
+        static $cache = null;
+
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        $apiclient = static::get_apiclient();
+        if (!$apiclient) {
+            $cache = ['notconnected', []];
+            return $cache;
+        }
+
+        try {
+            $schools = $apiclient->get_schools();
+        } catch (moodle_exception $e) {
+            $cache = ['error', []];
+            return $cache;
+        }
+
+        if (empty($schools)) {
+            $cache = ['noschools', []];
+            return $cache;
+        }
+
+        $result = [];
+        foreach ($schools as $school) {
+            $result[$school['id']] = $school['displayName'];
+        }
+
+        $cache = ['ok', $result];
+
+        return $cache;
+    }
+
+    /**
      * Return the configuration status of SDS profile sync, and the name of the school if configured.
      *
      * @param unified|null $apiclient

--- a/local/o365/lang/en/local_o365.php
+++ b/local/o365/lang/en/local_o365.php
@@ -735,6 +735,7 @@ $string['settings_sds_school_disabled_action'] = 'School sync disabled action';
 $string['settings_sds_school_disabled_action_desc'] = 'Action to the already connected Moodle courses when sync is disabled on an SDS school.';
 $string['settings_sds_school_disabled_action_keep_connected'] = 'Keep the Moodle course connected to the Team';
 $string['settings_sds_school_disabled_action_disconnect'] = 'Disconnect the Moodle course with the Team';
+$string['settings_sds_school_unavailable'] = '{$a} (SDS school list currently unavailable)';
 
 // Settings in the "Teams Settings" tab.
 $string['settings_teams_banner'] = 'The Moodle app for <a href="https://aka.ms/MoodleLearnTeams" target="_blank">Microsoft Teams</a> allows you to easily access and collaborate around your Moodle courses in Teams.';

--- a/local/o365/settings.php
+++ b/local/o365/settings.php
@@ -696,6 +696,9 @@ if ($hassiteconfig) {
         );
         $ADMIN->add('local_o365_folder', $sdssettings);
         if ($ADMIN->fulltree) {
+            // The SDS school list is loaded from the Graph API by local_o365\feature\sds\utils::get_settings_schools(),
+            // which is only called when a school-dependent setting or the status heading below is actually rendered.
+            // This keeps building the full admin tree (for example on /admin/search.php) free of Graph API calls.
             $sdssettings->add(new admin_setting_heading(
                 'local_o365_sds_nav',
                 '',
@@ -707,190 +710,166 @@ if ($hassiteconfig) {
             $desc .= new lang_string('settings_sds_intro_desc', 'local_o365', $scheduledtasks->out());
             $sdssettings->add(new admin_setting_heading('local_o365_sds_intro', '', $desc));
 
-            $apiclient = \local_o365\feature\sds\utils::get_apiclient();
-            if ($apiclient) {
-                try {
-                    $schools = $apiclient->get_schools();
+            // Informational heading shown when the school list cannot be retrieved.
+            $sdssettings->add(new \local_o365\adminsetting\sdsschoolsstatus('local_o365_sds_schools_status'));
 
-                    if (!empty($schools)) {
-                        // SDS course sync school selector header.
-                        $label = new lang_string('settings_sds_coursecreation', 'local_o365');
-                        $desc = new lang_string('settings_sds_coursecreation_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_heading('local_o365_sds_coursecreation', $label, $desc));
+            // SDS course sync school selector header.
+            $label = new lang_string('settings_sds_coursecreation', 'local_o365');
+            $desc = new lang_string('settings_sds_coursecreation_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_heading('local_o365_sds_coursecreation', $label, $desc));
 
-                        $label = new lang_string('settings_sds_coursecreation_enabled', 'local_o365');
-                        $desc = new lang_string('settings_sds_coursecreation_enabled_desc', 'local_o365');
-                        $coursesyncdefault = [];
-                        $coursesynchoices = [];
-                        $profilesyncchoices = [];
-                        foreach ($schools as $school) {
-                            $coursesynchoices[$school['id']] = $school['displayName'];
-                            $profilesyncchoices[$school['id']] = $school['displayName'] . ' (' . $school['id'] . ')';
-                        }
+            $label = new lang_string('settings_sds_coursecreation_enabled', 'local_o365');
+            $desc = new lang_string('settings_sds_coursecreation_enabled_desc', 'local_o365');
+            $sdssettings->add(new \local_o365\adminsetting\sdsschools(
+                'local_o365/sdsschools',
+                $label,
+                $desc,
+                [],
+                null
+            ));
 
-                        $sdssettings->add(new admin_setting_configmulticheckbox(
-                            'local_o365/sdsschools',
-                            $label,
-                            $desc,
-                            $coursesyncdefault,
-                            $coursesynchoices
-                        ));
+            $label = new lang_string('settings_sds_teams_enabled', 'local_o365');
+            $desc = new lang_string('settings_sds_teams_enabled_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdsteamsenabled', $label, $desc, '0'));
 
-                        $label = new lang_string('settings_sds_teams_enabled', 'local_o365');
-                        $desc = new lang_string('settings_sds_teams_enabled_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdsteamsenabled', $label, $desc, '0'));
+            $schooldisabledactionoptions = [
+                SDS_SCHOOL_DISABLED_ACTION_KEEP_CONNECTED => get_string(
+                    'settings_sds_school_disabled_action_keep_connected',
+                    'local_o365'
+                ),
+                SDS_SCHOOL_DISABLED_ACTION_DISCONNECT => get_string(
+                    'settings_sds_school_disabled_action_disconnect',
+                    'local_o365'
+                ),
+            ];
+            $label = new lang_string('settings_sds_school_disabled_action', 'local_o365');
+            $desc = new lang_string('settings_sds_school_disabled_action_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configselect(
+                'local_o365/sdsschooldisabledaction',
+                $label,
+                $desc,
+                SDS_SCHOOL_DISABLED_ACTION_KEEP_CONNECTED,
+                $schooldisabledactionoptions
+            ));
 
-                        $schooldisabledactionoptions = [
-                            SDS_SCHOOL_DISABLED_ACTION_KEEP_CONNECTED => get_string(
-                                'settings_sds_school_disabled_action_keep_connected',
-                                'local_o365'
-                            ),
-                            SDS_SCHOOL_DISABLED_ACTION_DISCONNECT => get_string(
-                                'settings_sds_school_disabled_action_disconnect',
-                                'local_o365'
-                            ),
-                        ];
-                        $label = new lang_string('settings_sds_school_disabled_action', 'local_o365');
-                        $desc = new lang_string('settings_sds_school_disabled_action_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configselect(
-                            'local_o365/sdsschooldisabledaction',
-                            $label,
-                            $desc,
-                            SDS_SCHOOL_DISABLED_ACTION_KEEP_CONNECTED,
-                            $schooldisabledactionoptions
-                        ));
+            // SDS categorize by subject.
+            $label = new lang_string('settings_sds_categorize_by_subject', 'local_o365');
+            $desc = new lang_string('settings_sds_categorize_by_subject_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox(
+                'local_o365/sdscategorizebysubject',
+                $label,
+                $desc,
+                '0'
+            ));
 
-                        // SDS categorize by subject.
-                        $label = new lang_string('settings_sds_categorize_by_subject', 'local_o365');
-                        $desc = new lang_string('settings_sds_categorize_by_subject_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox(
-                            'local_o365/sdscategorizebysubject',
-                            $label,
-                            $desc,
-                            '0'
-                        ));
+            // SDS ignore past courses.
+            $label = new lang_string('settings_sds_ignore_past_courses', 'local_o365');
+            $desc = new lang_string('settings_sds_ignore_past_courses_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdsignorepastclasses', $label, $desc, '0'));
 
-                        // SDS ignore past courses.
-                        $label = new lang_string('settings_sds_ignore_past_courses', 'local_o365');
-                        $desc = new lang_string('settings_sds_ignore_past_courses_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdsignorepastclasses', $label, $desc, '0'));
+            // SDS expired course prefix.
+            $label = new lang_string('settings_sds_expired_course_prefix', 'local_o365');
+            $desc = new lang_string('settings_sds_expired_course_prefix_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configtext(
+                'local_o365/sdsexpiredprefix',
+                $label,
+                $desc,
+                'Exp',
+                PARAM_TEXT
+            ));
+            $sdssettings->hide_if(
+                'local_o365/sdsexpiredprefix',
+                'local_o365/sdsignorepastclasses',
+                'notchecked'
+            );
 
-                        // SDS expired course prefix.
-                        $label = new lang_string('settings_sds_expired_course_prefix', 'local_o365');
-                        $desc = new lang_string('settings_sds_expired_course_prefix_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configtext(
-                            'local_o365/sdsexpiredprefix',
-                            $label,
-                            $desc,
-                            'Exp',
-                            PARAM_TEXT
-                        ));
-                        $sdssettings->hide_if(
-                            'local_o365/sdsexpiredprefix',
-                            'local_o365/sdsignorepastclasses',
-                            'notchecked'
-                        );
+            // SDS cohort sync header.
+            $label = new lang_string('settings_sds_cohortsync', 'local_o365');
+            $desc = new lang_string('settings_sds_cohortsync_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_heading('local_o365_sds_cohortsync', $label, $desc));
 
-                        // SDS cohort sync header.
-                        $label = new lang_string('settings_sds_cohortsync', 'local_o365');
-                        $desc = new lang_string('settings_sds_cohortsync_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_heading('local_o365_sds_cohortsync', $label, $desc));
+            // SDS create cohorts.
+            $label = new lang_string('settings_sds_create_cohorts', 'local_o365');
+            $desc = new lang_string('settings_sds_create_cohorts_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdscreatecohorts', $label, $desc, '0'));
 
-                        // SDS create cohorts.
-                        $label = new lang_string('settings_sds_create_cohorts', 'local_o365');
-                        $desc = new lang_string('settings_sds_create_cohorts_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdscreatecohorts', $label, $desc, '0'));
+            // SDS cohort include teachers.
+            $label = new lang_string('settings_sds_cohort_include_teachers', 'local_o365');
+            $desc = new lang_string('settings_sds_cohort_include_teachers_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox(
+                'local_o365/sdscohortincludeteachers',
+                $label,
+                $desc,
+                '0'
+            ));
 
-                        // SDS cohort include teachers.
-                        $label = new lang_string('settings_sds_cohort_include_teachers', 'local_o365');
-                        $desc = new lang_string('settings_sds_cohort_include_teachers_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox(
-                            'local_o365/sdscohortincludeteachers',
-                            $label,
-                            $desc,
-                            '0'
-                        ));
+            $label = new lang_string('settings_sds_courseenrolsync', 'local_o365');
+            $desc = new lang_string('settings_sds_courseenrolsync_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_heading('local_o365_sds_courseenrolsync', $label, $desc));
 
-                        $label = new lang_string('settings_sds_courseenrolsync', 'local_o365');
-                        $desc = new lang_string('settings_sds_courseenrolsync_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_heading('local_o365_sds_courseenrolsync', $label, $desc));
+            // SDS to Moodle enrolment sync.
+            $label = new lang_string('settings_sds_enrolment_enabled', 'local_o365');
+            $desc = new lang_string('settings_sds_enrolment_enabled_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox(
+                'local_o365/sdsenrolmentenabled',
+                $label,
+                $desc,
+                '1'
+            ));
 
-                        // SDS to Moodle enrolment sync.
-                        $label = new lang_string('settings_sds_enrolment_enabled', 'local_o365');
-                        $desc = new lang_string('settings_sds_enrolment_enabled_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox(
-                            'local_o365/sdsenrolmentenabled',
-                            $label,
-                            $desc,
-                            '1'
-                        ));
+            // Moodle to SDS enrolment sync.
+            $label = new lang_string('settings_sds_sync_enrolment_to_sds', 'local_o365');
+            $desc = new lang_string('settings_sds_sync_enrolment_to_sds_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox(
+                'local_o365/sdssyncenrolmenttosds',
+                $label,
+                $desc,
+                '0'
+            ));
 
-                        // Moodle to SDS enrolment sync.
-                        $label = new lang_string('settings_sds_sync_enrolment_to_sds', 'local_o365');
-                        $desc = new lang_string('settings_sds_sync_enrolment_to_sds_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox(
-                            'local_o365/sdssyncenrolmenttosds',
-                            $label,
-                            $desc,
-                            '0'
-                        ));
+            // SDS enrolment suspension setting.
+            $label = new lang_string('settings_sds_suspend_enrolment', 'local_o365');
+            $desc = new lang_string('settings_sds_suspend_enrolment_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdssuspendenrolment', $label, $desc, '1'));
 
-                        // SDS enrolment suspension setting.
-                        $label = new lang_string('settings_sds_suspend_enrolment', 'local_o365');
-                        $desc = new lang_string('settings_sds_suspend_enrolment_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdssuspendenrolment', $label, $desc, '1'));
+            // SDS two-way course sync setting.
+            $label = new lang_string('settings_sds_enable_course_sync', 'local_o365');
+            $desc = new lang_string('settings_sds_enable_course_sync_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdsenablecoursesync', $label, $desc, '0'));
 
-                        // SDS two-way course sync setting.
-                        $label = new lang_string('settings_sds_enable_course_sync', 'local_o365');
-                        $desc = new lang_string('settings_sds_enable_course_sync_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configcheckbox('local_o365/sdsenablecoursesync', $label, $desc, '0'));
+            $label = new lang_string('settings_sds_enrolment_teacher_role', 'local_o365');
+            $desc = new lang_string('settings_sds_enrolment_teacher_role_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configselect(
+                'local_o365/sdsenrolmentteacherrole',
+                $label,
+                $desc,
+                3,
+                $courseroleoptions
+            ));
 
-                        $label = new lang_string('settings_sds_enrolment_teacher_role', 'local_o365');
-                        $desc = new lang_string('settings_sds_enrolment_teacher_role_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configselect(
-                            'local_o365/sdsenrolmentteacherrole',
-                            $label,
-                            $desc,
-                            3,
-                            $courseroleoptions
-                        ));
+            $label = new lang_string('settings_sds_enrolment_student_role', 'local_o365');
+            $desc = new lang_string('settings_sds_enrolment_student_role_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_configselect(
+                'local_o365/sdsenrolmentstudentrole',
+                $label,
+                $desc,
+                5,
+                $courseroleoptions
+            ));
 
-                        $label = new lang_string('settings_sds_enrolment_student_role', 'local_o365');
-                        $desc = new lang_string('settings_sds_enrolment_student_role_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configselect(
-                            'local_o365/sdsenrolmentstudentrole',
-                            $label,
-                            $desc,
-                            5,
-                            $courseroleoptions
-                        ));
+            $label = new lang_string('settings_sds_profilesync_header', 'local_o365');
+            $desc = new lang_string('settings_sds_profilesync_header_desc', 'local_o365');
+            $sdssettings->add(new admin_setting_heading('local_o365_sds_profilesync_header', $label, $desc));
 
-                        $label = new lang_string('settings_sds_profilesync_header', 'local_o365');
-                        $desc = new lang_string('settings_sds_profilesync_header_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_heading('local_o365_sds_profilesync_header', $label, $desc));
-
-                        asort($profilesyncchoices);
-                        $profilesyncchoices = ['' => new lang_string('settings_sds_profilesync_disabled', 'local_o365')]
-                            + $profilesyncchoices;
-
-                        $label = new lang_string('settings_sds_profilesync', 'local_o365');
-                        $desc = new lang_string('settings_sds_profilesync_desc', 'local_o365');
-                        $sdssettings->add(new admin_setting_configselect(
-                            'local_o365/sdsprofilesync',
-                            $label,
-                            $desc,
-                            '0',
-                            $profilesyncchoices
-                        ));
-                    } else {
-                        $desc = new lang_string('settings_sds_noschools', 'local_o365');
-                        $sdssettings->add(new admin_setting_heading('local_o365_sds_noschools', '', $desc));
-                    }
-                } catch (moodle_exception $e) {
-                    $desc = new lang_string('settings_sds_get_schools_error', 'local_o365');
-                    $sdssettings->add(new admin_setting_heading('local_o365_sds_get_schools_error', '', $desc));
-                }
-            }
+            $label = new lang_string('settings_sds_profilesync', 'local_o365');
+            $desc = new lang_string('settings_sds_profilesync_desc', 'local_o365');
+            $sdssettings->add(new \local_o365\adminsetting\sdsprofilesync(
+                'local_o365/sdsprofilesync',
+                $label,
+                $desc,
+                '0',
+                null
+            ));
         }
 
         // TEAMS PAGE.
@@ -983,34 +962,12 @@ if ($hassiteconfig) {
                     local_o365_get_settings_nav_html('local_o365_moodle_app')
                 ));
 
-                $moodleappiddescription = get_string('settings_moodle_app_id_desc', 'local_o365');
-                if (\local_o365\utils::is_connected() === true) {
-                    $graphclient = \local_o365\utils::get_api();
-                    if ($graphclient) {
-                        $teamsmoodleappexternalid = get_config('local_o365', 'teams_moodle_app_external_id');
-                        if (!$teamsmoodleappexternalid) {
-                            $teamsmoodleappexternalid = TEAMS_MOODLE_APP_EXTERNAL_ID;
-                        }
-                        $moodleappid = '';
-                        try {
-                            $moodleappid = $graphclient->get_catalog_app_id($teamsmoodleappexternalid);
-                        } catch (moodle_exception $e) {
-                            debugging('Error getting catalog app ID. Details: ' . $e->getMessage(), DEBUG_NORMAL);
-                        }
-                        if ($moodleappid) {
-                            $moodleappiddescription .= get_string(
-                                'settings_moodle_app_id_desc_auto_id',
-                                'local_o365',
-                                $moodleappid
-                            );
-                        }
-                    }
-                }
-
-                $moodleappsettings->add(new admin_setting_configtext(
+                // The auto-detected catalog app ID is appended to the description by the setting itself when it is
+                // rendered, so building the full admin tree (for example on /admin/search.php) makes no Graph API call.
+                $moodleappsettings->add(new \local_o365\adminsetting\moodleappid(
                     'local_o365/moodle_app_id',
                     get_string('settings_moodle_app_id', 'local_o365'),
-                    $moodleappiddescription,
+                    get_string('settings_moodle_app_id_desc', 'local_o365'),
                     '',
                     PARAM_TEXT,
                     36


### PR DESCRIPTION
Follow-up to the $ADMIN->fulltree guard from issue #3416, tracked in issue #3475. Building the full admin tree (for example on /admin/search.php) still triggered two Graph API calls: get_schools() on the SDS page and get_catalog_app_id() on the Moodle app page. Neither result is used when searching settings, which only matches on the static name, visible name and description.

Register the settings unconditionally and load the Graph-dependent data lazily, only when the setting is actually rendered:

- \local_o365\feature\sds\utils::get_settings_schools() fetches the school list at most once per request and reports the status (ok / notconnected / noschools / error).
- \local_o365\adminsetting\sdsschools and \local_o365\adminsetting\sdsprofilesync load their choices via load_choices(); is_related() matches only the static metadata so searching the admin settings makes no Graph API call. sdsprofilesync also skips write_setting() when the school list is unavailable, so a transient failure cannot wipe a configured school.
- \local_o365\adminsetting\sdsschoolsstatus renders the no-schools / error message on demand.
- \local_o365\adminsetting\moodleappid appends the auto-detected catalog app ID to its description in output_html().

Result: full admin-tree builds make no Graph API calls; the calls now happen only when the SDS or Moodle app settings page is viewed.