### PR TITLE
local_o365: Fix Teams owner/member sync reliability issues

### DIFF
--- a/local/o365/classes/feature/coursesync/main.php
+++ b/local/o365/classes/feature/coursesync/main.php
@@ -93,6 +93,21 @@ class main {
      * @var bool whether the tenant has education license.
      */
     private $haseducationlicense = false;
+    /**
+     * @var array Object IDs of groups that Microsoft Graph reported as non-existent during this run, so that
+     * further calls against them are skipped instead of repeatedly failing.
+     */
+    private $groupsnotfound = [];
+    /**
+     * @var array Object IDs of groups created during this run, which may not be fully visible to Graph yet and
+     * therefore warrant extra propagation retries.
+     */
+    private $newgroups = [];
+    /**
+     * @var array Object IDs of users that Microsoft Graph reported as non-existent during this run, so that
+     * further attempts to add them to a group are skipped.
+     */
+    private $usersnotfound = [];
 
     /**
      * Constructor.
@@ -411,20 +426,18 @@ class main {
         array $members,
         int $baselevel = 3
     ): bool {
-        global $SESSION;
         if (empty($owners) && empty($members)) {
             $this->mtrace('Skip adding owners / members to the group. Reason: No users to add.', $baselevel);
             return false;
         }
 
         // Whether this group was just created in this run (prone to Azure AD propagation delay).
-        $isnewlycreated = isset($SESSION->o365_newly_created_groups) &&
-            in_array($groupobjectid, $SESSION->o365_newly_created_groups);
+        $isnewlycreated = in_array($groupobjectid, $this->newgroups);
 
         // Fetch existing owners, retrying for newly created groups to handle Azure AD propagation delay.
         $existingowners = [];
         $this->mtrace('Get existing owners of group with ID ' . $groupobjectid, $baselevel);
-        if (isset($SESSION->o365_groups_not_exist) && in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
+        if (in_array($groupobjectid, $this->groupsnotfound)) {
             $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
         } else {
             $fetchretry = 0;
@@ -454,12 +467,11 @@ class main {
                             $baselevel + 1
                         );
                         if (
-                            isset($SESSION->o365_groups_not_exist) && isset($SESSION->o365_newly_created_groups) &&
                             static::is_resource_not_exist_exception($e->getMessage()) &&
                             stripos($e->getMessage(), $groupobjectid) !== false
                         ) {
-                            if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                                $SESSION->o365_groups_not_exist[] = $groupobjectid;
+                            if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                                $this->groupsnotfound[] = $groupobjectid;
                             }
                             $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
                         }
@@ -473,7 +485,7 @@ class main {
         // Fetch existing members, retrying for newly created groups to handle Azure AD propagation delay.
         $existingmembers = [];
         $this->mtrace('Get existing members of group with ID ' . $groupobjectid, $baselevel);
-        if (isset($SESSION->o365_groups_not_exist) && in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
+        if (in_array($groupobjectid, $this->groupsnotfound)) {
             $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
         } else {
             $fetchretry = 0;
@@ -503,12 +515,11 @@ class main {
                             $baselevel + 1
                         );
                         if (
-                            isset($SESSION->o365_groups_not_exist) &&
                             static::is_resource_not_exist_exception($e->getMessage()) &&
                             stripos($e->getMessage(), $groupobjectid) !== false
                         ) {
-                            if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                                $SESSION->o365_groups_not_exist[] = $groupobjectid;
+                            if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                                $this->groupsnotfound[] = $groupobjectid;
                             }
                             $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
                         }
@@ -533,70 +544,168 @@ class main {
 
         foreach ($userchunks as $key => $userchunk) {
             $role = array_keys($userchunk)[0];
-            $users = reset($userchunk);
+            $users = array_values(reset($userchunk));
+
+            if (in_array($groupobjectid, $this->groupsnotfound)) {
+                $this->mtrace('Group does not exist. Skipping remaining chunks.', $baselevel + 1);
+                break;
+            }
+
+            // Drop users already known not to exist in this run.
+            $users = array_values(array_diff($users, $this->usersnotfound));
+            if (empty($users)) {
+                continue;
+            }
+
+            $this->mtrace('Chunk ' . ($key + 1) . ', adding ' . count($users) . ' users as ' . $role, $baselevel + 1);
+
+            $chunkdone = false;
+            $groupmissing = false;
             $retrycounter = 0;
-            while ($retrycounter <= API_CALL_RETRY_LIMIT) {
+            while (!$chunkdone && $retrycounter <= API_CALL_RETRY_LIMIT) {
                 if ($retrycounter) {
-                    $this->mtrace('Retry #' . $retrycounter, $baselevel + 1);
+                    $this->mtrace('Retry #' . $retrycounter, $baselevel + 2);
                     sleep(10);
                 }
 
                 try {
-                    $this->mtrace('Chunk ' . ($key + 1) . ', adding ' . count($users) . ' users as ' . $role, $baselevel + 1);
-
-                    if (isset($SESSION->o365_groups_not_exist)) {
-                        if (in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                            $this->mtrace('Group does not exist. Skipping.', $baselevel + 2);
-                            break;
-                        }
-                    }
-
                     $response = $this->graphclient->add_chunk_users_to_group($groupobjectid, $role, $users);
                     if ($response) {
                         if ($role == 'owner') {
                             $owneradded = true;
                         }
+                        $chunkdone = true;
                     } else {
-                        $this->mtrace('Invalid bulk group owners/members addition request', $baselevel + 2);
+                        // A non-exception failure (unexpected response code): retry, then fall back to per-user adds.
+                        $this->mtrace('Bulk owners / members addition returned an unexpected response.', $baselevel + 2);
+                        $retrycounter++;
                     }
-
-                    break;
                 } catch (moodle_exception $e) {
                     $this->mtrace('Error: ' . $e->getMessage(), $baselevel + 2);
-                    if (
-                        isset($SESSION->o365_groups_not_exist) && isset($SESSION->o365_newly_created_groups) &&
-                        isset($SESSION->o365_users_not_exist)
-                    ) {
-                        if (static::is_resource_not_exist_exception($e->getMessage())) {
-                            if (stripos($e->getMessage(), $groupobjectid) !== false) {
-                                // The non-existing resource is the group.
-                                if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                                    $SESSION->o365_groups_not_exist[] = $groupobjectid;
-                                }
 
-                                $this->mtrace('Group does not exist. Skip retries.', $baselevel + 2);
-                                break;
-                            } else {
-                                // The non-existing resource is a user.
-                                $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
-                                if (!empty($useroid) && !in_array($useroid, $SESSION->o365_users_not_exist)) {
-                                    $SESSION->o365_users_not_exist[] = $useroid;
-                                    $this->mtrace('User ' . $useroid . ' does not exist. Skip retries.', $baselevel + 2);
-                                } else {
-                                    $this->mtrace('User does not exist. Skip retries.', $baselevel + 2);
-                                }
-
-                                break;
+                    if (static::is_resource_not_exist_exception($e->getMessage())) {
+                        if (stripos($e->getMessage(), $groupobjectid) !== false) {
+                            // The non-existing resource is the group - nothing more can be done for it this run.
+                            if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                                $this->groupsnotfound[] = $groupobjectid;
                             }
+                            $this->mtrace('Group does not exist. Skip retries.', $baselevel + 2);
+                            $chunkdone = true;
+                            $groupmissing = true;
+                            break;
+                        }
+
+                        // The non-existing resource is a user. Graph rejects the whole request when any single
+                        // reference is invalid, so drop the offending user and retry the rest of the chunk.
+                        $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
+                        if (!empty($useroid) && in_array($useroid, $users)) {
+                            if (!in_array($useroid, $this->usersnotfound)) {
+                                $this->usersnotfound[] = $useroid;
+                            }
+                            $this->mtrace('User ' . $useroid . ' does not exist. Removing from chunk.', $baselevel + 2);
+                            $users = array_values(array_diff($users, [$useroid]));
+                            if (empty($users)) {
+                                $chunkdone = true;
+                            }
+                            // Retry immediately with the reduced chunk (not counted as a backoff retry).
+                            continue;
                         }
                     }
 
                     $retrycounter++;
                 }
             }
+
+            if ($groupmissing) {
+                break;
+            }
+
+            if (!$chunkdone && !empty($users)) {
+                // The bulk request kept failing for a reason that is not a single missing user (e.g. one user is
+                // already an owner / member, or a transient error affecting one reference). Fall back to adding the
+                // users one by one so that a single bad reference does not block the whole chunk.
+                $fallbackmessage = 'Bulk add failed; falling back to individual add for ' . count($users) . ' user(s).';
+                $this->mtrace($fallbackmessage, $baselevel + 1);
+                if ($this->add_users_to_group_individually($groupobjectid, $role, $users, $baselevel + 2)) {
+                    if ($role == 'owner') {
+                        $owneradded = true;
+                    }
+                }
+            }
         }
 
         return $owneradded;
+    }
+
+    /**
+     * Add each of the given users to the group one at a time.
+     *
+     * Used as a fallback when a bulk add request is rejected because of a single bad user reference: Microsoft
+     * Graph rejects the entire request in that case, so one stale or already-present object ID would otherwise
+     * block every other user in the same chunk. "Already exists" errors are treated as success, and users that no
+     * longer exist are recorded so they are skipped for the rest of the run.
+     *
+     * @param string $groupobjectid
+     * @param string $role 'owner' or 'member'.
+     * @param array $userobjectids
+     * @param int $baselevel
+     * @return bool Whether at least one user ended up present as the requested role.
+     */
+    private function add_users_to_group_individually(
+        string $groupobjectid,
+        string $role,
+        array $userobjectids,
+        int $baselevel = 4
+    ): bool {
+        $added = false;
+
+        foreach ($userobjectids as $userobjectid) {
+            if (in_array($userobjectid, $this->usersnotfound)) {
+                continue;
+            }
+
+            if (in_array($groupobjectid, $this->groupsnotfound)) {
+                break;
+            }
+
+            try {
+                if ($role === 'owner') {
+                    $this->add_owner_to_group($groupobjectid, $userobjectid);
+                } else {
+                    $this->add_member_to_group($groupobjectid, $userobjectid);
+                }
+                $this->mtrace('Added ' . $userobjectid . ' as ' . $role . '.', $baselevel);
+                $added = true;
+            } catch (moodle_exception $e) {
+                $message = $e->getMessage();
+
+                if (stripos($message, 'already exist') !== false) {
+                    // The user is already an owner / member - the intended end state is already in place.
+                    $added = true;
+                    continue;
+                }
+
+                if (static::is_resource_not_exist_exception($message)) {
+                    if (stripos($message, $groupobjectid) !== false) {
+                        if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                            $this->groupsnotfound[] = $groupobjectid;
+                        }
+                        $this->mtrace('Group does not exist. Aborting individual add.', $baselevel);
+                        break;
+                    }
+
+                    if (!in_array($userobjectid, $this->usersnotfound)) {
+                        $this->usersnotfound[] = $userobjectid;
+                    }
+                    $this->mtrace('User ' . $userobjectid . ' does not exist. Skipping.', $baselevel);
+                    continue;
+                }
+
+                $this->mtrace('Error adding ' . $userobjectid . ' as ' . $role . ': ' . $message, $baselevel);
+            }
+        }
+
+        return $added;
     }
 
     /**
@@ -752,7 +861,7 @@ class main {
      * @return array|false
      */
     private function create_team_from_education_group(string $groupobjectid, stdClass $course, int $baselevel = 3) {
-        global $DB, $SESSION;
+        global $DB;
 
         $now = time();
 
@@ -768,8 +877,7 @@ class main {
 
         // Whether this group was just created in this run (prone to Azure AD propagation delay), meaning
         // an owner was already confirmed added even though a read-after-write owner check may still lag.
-        $isnewlycreated = isset($SESSION->o365_newly_created_groups) &&
-            in_array($groupobjectid, $SESSION->o365_newly_created_groups);
+        $isnewlycreated = in_array($groupobjectid, $this->newgroups);
 
         $templateconfig = $this->get_team_template_with_fallback('educationClass');
         $currenttemplate = $templateconfig['template'];
@@ -784,11 +892,9 @@ class main {
         $skipgenericretrymessage = false;
 
         while ($retrycounter <= API_CALL_RETRY_LIMIT) {
-            if (isset($SESSION->o365_groups_not_exist)) {
-                if (in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                    $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
-                    break;
-                }
+            if (in_array($groupobjectid, $this->groupsnotfound)) {
+                $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
+                break;
             }
 
             if ($retrycounter) {
@@ -869,32 +975,27 @@ class main {
                             $baselevel + 1
                         );
 
-                        if (
-                            isset($SESSION->o365_groups_not_exist) && isset($SESSION->o365_newly_created_groups) &&
-                            isset($SESSION->o365_users_not_exist)
-                        ) {
-                            if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                                if (static::is_resource_not_exist_exception($e->getMessage())) {
-                                    if (stripos($e->getMessage(), $groupobjectid) !== false) {
-                                        // The non-existing resource is the group.
-                                        if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                                            $SESSION->o365_groups_not_exist[] = $groupobjectid;
-                                        }
-
-                                        $this->mtrace('Group does not exist. Skip retries.', $baselevel + 2);
-                                        break;
-                                    } else {
-                                        // The non-existing resource is a user.
-                                        $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
-                                        if (!empty($useroid) && !in_array($useroid, $SESSION->o365_users_not_exist)) {
-                                            $SESSION->o365_users_not_exist[] = $useroid;
-                                            $this->mtrace('User ' . $useroid . ' does not exist. Skip retries.', $baselevel + 2);
-                                        } else {
-                                            $this->mtrace('User does not exist. Skip retries.', $baselevel + 2);
-                                        }
-
-                                        break;
+                        if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                            if (static::is_resource_not_exist_exception($e->getMessage())) {
+                                if (stripos($e->getMessage(), $groupobjectid) !== false) {
+                                    // The non-existing resource is the group.
+                                    if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                                        $this->groupsnotfound[] = $groupobjectid;
                                     }
+
+                                    $this->mtrace('Group does not exist. Skip retries.', $baselevel + 2);
+                                    break;
+                                } else {
+                                    // The non-existing resource is a user.
+                                    $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
+                                    if (!empty($useroid) && !in_array($useroid, $this->usersnotfound)) {
+                                        $this->usersnotfound[] = $useroid;
+                                        $this->mtrace('User ' . $useroid . ' does not exist. Skip retries.', $baselevel + 2);
+                                    } else {
+                                        $this->mtrace('User does not exist. Skip retries.', $baselevel + 2);
+                                    }
+
+                                    break;
                                 }
                             }
                         }
@@ -949,7 +1050,7 @@ class main {
      * @return array|false The team object record or false on failure.
      */
     private function create_plc_team_directly(stdClass $course, int $baselevel = 2): array|false {
-        global $DB, $SESSION;
+        global $DB;
 
         $now = time();
 
@@ -1057,8 +1158,8 @@ class main {
 
         // Register the new group as newly created so that add_group_owners_and_members_to_group will apply
         // retry logic when the group is not yet accessible due to Azure AD propagation delay.
-        if (isset($SESSION->o365_newly_created_groups) && !in_array($groupobjectid, $SESSION->o365_newly_created_groups)) {
-            $SESSION->o365_newly_created_groups[] = $groupobjectid;
+        if (!in_array($groupobjectid, $this->newgroups)) {
+            $this->newgroups[] = $groupobjectid;
         }
 
         // Add owners/members to the group (best-effort: the group may not yet be fully propagated in Azure AD).
@@ -1094,7 +1195,7 @@ class main {
      * @return array|false
      */
     private function create_team_from_standard_group(string $groupobjectid, stdClass $course, int $baselevel = 3) {
-        global $DB, $SESSION;
+        global $DB;
 
         $now = time();
 
@@ -1106,8 +1207,7 @@ class main {
 
         // Whether this group was just created in this run (prone to Azure AD propagation delay), meaning
         // an owner was already confirmed added even though a read-after-write owner check may still lag.
-        $isnewlycreated = isset($SESSION->o365_newly_created_groups) &&
-            in_array($groupobjectid, $SESSION->o365_newly_created_groups);
+        $isnewlycreated = in_array($groupobjectid, $this->newgroups);
 
         $templateconfig = $this->get_team_template_with_fallback('standard');
         $currenttemplate = $templateconfig['template'];
@@ -1154,11 +1254,9 @@ class main {
                 $retrycounter++;
             } else {
                 try {
-                    if (isset($SESSION->o365_groups_not_exist)) {
-                        if (in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                            $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
-                            break;
-                        }
+                    if (in_array($groupobjectid, $this->groupsnotfound)) {
+                        $this->mtrace('Group does not exist. Skipping.', $baselevel + 1);
+                        break;
                     }
 
                     $response = $this->graphclient->create_team_from_group($groupobjectid, $currenttemplate);
@@ -1222,32 +1320,27 @@ class main {
 
                     $this->mtrace('Could not create team from group. Reason: ' . $e->getMessage(), $baselevel + 1);
 
-                    if (
-                        isset($SESSION->o365_groups_not_exist) && isset($SESSION->o365_newly_created_groups) &&
-                        isset($SESSION->o365_users_not_exist)
-                    ) {
-                        if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                            if (static::is_resource_not_exist_exception($e->getMessage())) {
-                                if (stripos($e->getMessage(), $groupobjectid) !== false) {
-                                    // The non-existing resource is the group.
-                                    if (!in_array($groupobjectid, $SESSION->o365_groups_not_exist)) {
-                                        $SESSION->o365_groups_not_exist[] = $groupobjectid;
-                                    }
-
-                                    $this->mtrace('Group does not exist. Skip retries.', $baselevel + 2);
-                                    break;
-                                } else {
-                                    // The non-existing resource is a user.
-                                    $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
-                                    if (!empty($useroid) && !in_array($useroid, $SESSION->o365_users_not_exist)) {
-                                        $SESSION->o365_users_not_exist[] = $useroid;
-                                        $this->mtrace('User ' . $useroid . ' does not exist. Skip retries.', $baselevel + 2);
-                                    } else {
-                                        $this->mtrace('User does not exist. Skip retries.', $baselevel + 2);
-                                    }
-
-                                    break;
+                    if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                        if (static::is_resource_not_exist_exception($e->getMessage())) {
+                            if (stripos($e->getMessage(), $groupobjectid) !== false) {
+                                // The non-existing resource is the group.
+                                if (!in_array($groupobjectid, $this->groupsnotfound)) {
+                                    $this->groupsnotfound[] = $groupobjectid;
                                 }
+
+                                $this->mtrace('Group does not exist. Skip retries.', $baselevel + 2);
+                                break;
+                            } else {
+                                // The non-existing resource is a user.
+                                $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
+                                if (!empty($useroid) && !in_array($useroid, $this->usersnotfound)) {
+                                    $this->usersnotfound[] = $useroid;
+                                    $this->mtrace('User ' . $useroid . ' does not exist. Skip retries.', $baselevel + 2);
+                                } else {
+                                    $this->mtrace('User does not exist. Skip retries.', $baselevel + 2);
+                                }
+
+                                break;
                             }
                         }
                     }
@@ -1476,8 +1569,6 @@ class main {
      * @return bool True if group creation succeeds, or False if it fails.
      */
     public function create_group_for_course(stdClass $course, int $baselevel = 2): bool {
-        global $SESSION;
-
         $this->mtrace('Process course #' . $course->id, $baselevel);
 
         // Check if a direct team creation template is configured (educationStaff, educationProfessionalLearningCommunity).
@@ -1489,9 +1580,7 @@ class main {
                 return false;
             }
 
-            if (isset($SESSION->o365_newly_created_groups)) {
-                $SESSION->o365_newly_created_groups[] = $teamobject['objectid'];
-            }
+            $this->newgroups[] = $teamobject['objectid'];
 
             $this->mtrace('Finished processing course #' . $course->id, $baselevel);
             return true;
@@ -1525,9 +1614,7 @@ class main {
             }
         }
 
-        if (isset($SESSION->o365_newly_created_groups)) {
-            $SESSION->o365_newly_created_groups[] = $groupobject['objectid'];
-        }
+        $this->newgroups[] = $groupobject['objectid'];
 
         $groupcreatedtime = time();
 
@@ -1589,7 +1676,7 @@ class main {
      *  - Create Teams if appropriate.
      */
     private function process_courses_without_teams() {
-        global $DB, $SESSION;
+        global $DB;
 
         $this->mtrace('Process courses without teams...', 1);
 
@@ -1639,10 +1726,8 @@ class main {
             $members = utils::get_team_member_object_ids_by_course_id($course->id, $owners);
 
             // Verify that at least one owner exists.
-            if (isset($SESSION->o365_users_not_exist)) {
-                $owners = array_diff($owners, $SESSION->o365_users_not_exist);
-                $members = array_diff($members, $SESSION->o365_users_not_exist);
-            }
+            $owners = array_diff($owners, $this->usersnotfound);
+            $members = array_diff($members, $this->usersnotfound);
 
             $ownerexists = false;
             foreach ($owners as $owner) {
@@ -1652,19 +1737,15 @@ class main {
                         $ownerexists = true;
                         break;
                     } else {
-                        if (isset($SESSION->o365_users_not_exist)) {
-                            if (!in_array($owner, $SESSION->o365_users_not_exist)) {
-                                $SESSION->o365_users_not_exist[] = $owner;
-                            }
+                        if (!in_array($owner, $this->usersnotfound)) {
+                            $this->usersnotfound[] = $owner;
                         }
                     }
                 } catch (moodle_exception $e) {
-                    if (isset($SESSION->o365_users_not_exist)) {
-                        if (static::is_resource_not_exist_exception($e->getMessage())) {
-                            $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
-                            if (!empty($useroid) && !in_array($useroid, $SESSION->o365_users_not_exist)) {
-                                $SESSION->o365_users_not_exist[] = $useroid;
-                            }
+                    if (static::is_resource_not_exist_exception($e->getMessage())) {
+                        $useroid = \local_o365\utils::extract_guid_from_error_message($e->getMessage());
+                        if (!empty($useroid) && !in_array($useroid, $this->usersnotfound)) {
+                            $this->usersnotfound[] = $useroid;
                         }
                     }
                 }
@@ -2942,11 +3023,11 @@ class main {
      * @return void
      */
     public function save_not_found_groups(): void {
-        global $DB, $SESSION;
+        global $DB;
 
         $this->mtrace('Save non-existing groups to groups cache...');
-        if ($SESSION->o365_groups_not_exist) {
-            foreach ($SESSION->o365_groups_not_exist as $groupid) {
+        if ($this->groupsnotfound) {
+            foreach ($this->groupsnotfound as $groupid) {
                 if ($existingrecord = $DB->get_record('local_o365_groups_cache', ['objectid' => $groupid])) {
                     if (!$existingrecord->not_found_since) {
                         $existingrecord->not_found_since = time();

--- a/local/o365/classes/feature/coursesync/utils.php
+++ b/local/o365/classes/feature/coursesync/utils.php
@@ -741,12 +741,18 @@ class utils {
 
         $coursecontext = course::instance($courseid);
 
-        // Get user roles in the course.
-        $userroles = get_user_roles($coursecontext, $userid, false);
+        // Get the user's role assignments that apply in the course context, including those inherited from parent
+        // contexts (category / system). This matches the capability resolution used by get_enrolled_users() in
+        // get_team_owner_user_ids_by_course_id() / get_team_member_user_ids_by_course_id(), so that the per-user
+        // sync and the bulk sync agree on who should be an owner or a member.
+        $userroles = get_user_roles($coursecontext, $userid, true);
         $userroleids = array_column($userroles, 'roleid');
         if ($excluderoleid) {
-            unset($userroleids[$excluderoleid]);
+            // Disregard the excluded role (used when handling a role_unassigned event). $userroleids is a
+            // sequentially indexed list of role IDs, so the excluded role must be filtered out by value.
+            $userroleids = array_diff($userroleids, [$excluderoleid]);
         }
+        $userroleids = array_unique($userroleids);
 
         // Get group owner and member roles.
         $ownerroles = get_roles_with_capability('local/o365:teamowner', CAP_ALLOW, $coursecontext);

--- a/local/o365/classes/task/coursesync.php
+++ b/local/o365/classes/task/coursesync.php
@@ -50,12 +50,6 @@ class coursesync extends scheduled_task {
      * @return bool|void
      */
     public function execute() {
-        global $SESSION;
-
-        $SESSION->o365_groups_not_exist = [];
-        $SESSION->o365_newly_created_groups = [];
-        $SESSION->o365_users_not_exist = [];
-
         // Raise memory and time limits to handle large numbers of teams/groups.
         raise_memory_limit(MEMORY_HUGE);
         @set_time_limit(0);

--- a/local/o365/classes/task/groupmembershipsync.php
+++ b/local/o365/classes/task/groupmembershipsync.php
@@ -26,8 +26,11 @@
 namespace local_o365\task;
 
 use core\task\adhoc_task;
+use core\task\manager;
 use local_o365\feature\coursesync\main;
+use local_o365\feature\coursesync\utils as coursesyncutils;
 use local_o365\utils;
+use Throwable;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -36,12 +39,40 @@ require_once($CFG->dirroot . '/local/o365/lib.php');
 /**
  * Ad-hoc task to sync Moodle course role assignment changes to Microsoft Groups.
  *
+ * The task reconciles owners and members for every sync-enabled course that has a connected group. Because that
+ * can be a large number of courses and each one needs several Microsoft Graph calls, the work is processed in
+ * bounded batches: each run handles up to "courses_per_task" courses and, if more remain, queues a follow-up task
+ * with the outstanding course IDs. This keeps individual runs short enough to finish within the cron time limit
+ * and, on failure, to be retried without starving the courses at the end of the list.
+ *
  * @package     local_o365
  * @subpackage  local_o365\task
  */
 class groupmembershipsync extends adhoc_task {
     /**
-     * Check if the course sync feature is enabled, get all courses that are enabled for sync, and resync owners and members.
+     * Default number of courses to process in a single run when the "courses_per_task" setting is not usable.
+     */
+    const DEFAULT_BATCH_SIZE = 20;
+
+    /**
+     * Maximum number of times a course that keeps failing is carried over into a follow-up task before it is
+     * given up on (until the next event re-triggers a sync). Prevents a permanently broken course from making
+     * the follow-up chain run forever.
+     */
+    const MAX_COURSE_ATTEMPTS = 3;
+
+    /**
+     * Return a human-readable name for this task (shown in the admin task log UI).
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        return get_string('task_groupmembershipsync', 'local_o365');
+    }
+
+    /**
+     * Check if the course sync feature is enabled, get the courses that still need processing, and resync owners
+     * and members for a bounded batch of them.
      *
      * @return false|void
      */
@@ -53,18 +84,122 @@ class groupmembershipsync extends adhoc_task {
             return false;
         }
 
-        if (utils::is_connected() !== true || \local_o365\feature\coursesync\utils::is_enabled() !== true) {
+        if (utils::is_connected() !== true || coursesyncutils::is_enabled() !== true) {
             return false;
         }
 
-        $graphclient = \local_o365\feature\coursesync\utils::get_unified_api();
-        if ($graphclient) {
-            $coursesync = new main($graphclient);
+        $graphclient = coursesyncutils::get_unified_api();
+        if (!$graphclient) {
+            return false;
+        }
 
-            $coursesenabled = \local_o365\feature\coursesync\utils::get_enabled_courses(true);
-            foreach ($coursesenabled as $courseid) {
+        // Raise limits: a batch still involves several Graph calls per course.
+        raise_memory_limit(MEMORY_HUGE);
+        @set_time_limit(0);
+
+        $courseids = $this->get_courses_to_process();
+        if (empty($courseids)) {
+            mtrace('No connected sync-enabled courses to process.');
+            return;
+        }
+
+        // Keep the order deterministic so that a given set of remaining courses always produces the same
+        // follow-up custom data, letting queue_adhoc_task() deduplicate it.
+        sort($courseids);
+
+        $batchsize = (int) get_config('local_o365', 'courses_per_task');
+        if ($batchsize <= 0) {
+            $batchsize = self::DEFAULT_BATCH_SIZE;
+        }
+
+        $batch = array_slice($courseids, 0, $batchsize);
+        $remaining = array_slice($courseids, $batchsize);
+
+        mtrace('Processing ' . count($batch) . ' course(s); ' . count($remaining) . ' queued for follow-up.');
+
+        // Per-course failure counts carried over from earlier runs, keyed by course ID.
+        $data = $this->get_custom_data();
+        $attempts = ($data && !empty($data->attempts)) ? (array) $data->attempts : [];
+
+        $retrycourseids = [];
+        $coursesync = new main($graphclient);
+        foreach ($batch as $courseid) {
+            $courseid = (int) $courseid;
+            try {
                 $coursesync->process_course_team_user_sync_from_moodle_to_microsoft($courseid);
+                // Success - forget any earlier failures for this course.
+                unset($attempts[$courseid]);
+            } catch (Throwable $e) {
+                // Isolate per-course failures so one bad course does not abort the whole batch (and prevent the
+                // follow-up task from being queued).
+                mtrace('Error syncing owners / members for course ' . $courseid . ': ' . $e->getMessage());
+                utils::debug('Exception: ' . $e->getMessage(), __METHOD__, $e);
+
+                $attemptcount = (int) ($attempts[$courseid] ?? 0) + 1;
+                if ($attemptcount < self::MAX_COURSE_ATTEMPTS) {
+                    // Give transient errors another attempt via the follow-up task.
+                    $attempts[$courseid] = $attemptcount;
+                    $retrycourseids[] = $courseid;
+                } else {
+                    mtrace('Course ' . $courseid . ' failed ' . $attemptcount . ' times; giving up until next sync.');
+                    unset($attempts[$courseid]);
+                }
             }
         }
+
+        $followupcourseids = array_values(array_unique(array_merge($remaining, $retrycourseids)));
+        if (!empty($followupcourseids)) {
+            // Only carry forward failure counts for courses that are actually in the follow-up list.
+            $attempts = array_intersect_key($attempts, array_flip($followupcourseids));
+
+            $customdata = ['courseids' => $followupcourseids];
+            if (!empty($attempts)) {
+                $customdata['attempts'] = $attempts;
+            }
+            $followup = new groupmembershipsync();
+            $followup->set_custom_data($customdata);
+            // Pass true to skip queueing when an identical follow-up already exists: this task may be retried, or
+            // run concurrently, and re-queueing the same remaining course list would only add redundant load.
+            manager::queue_adhoc_task($followup, true);
+            mtrace('Queued follow-up for ' . count($followupcourseids) . ' course(s) (' . count($retrycourseids) . ' retried).');
+        }
+    }
+
+    /**
+     * Return the list of course IDs this run should work through.
+     *
+     * When the task carries custom data with a "courseids" list (a follow-up of an earlier run), that list is
+     * used as-is. Otherwise the full set of sync-enabled courses that currently have a connected group is built.
+     *
+     * @return array Array of course IDs.
+     */
+    private function get_courses_to_process(): array {
+        global $DB;
+
+        $data = $this->get_custom_data();
+        if ($data && !empty($data->courseids) && is_array($data->courseids)) {
+            return array_values(array_filter(array_map('intval', $data->courseids)));
+        }
+
+        // All courses that currently have a connected group, excluding the site course.
+        $sql = "SELECT DISTINCT obj.moodleid
+                  FROM {local_o365_objects} obj
+                  JOIN {course} c ON c.id = obj.moodleid
+                 WHERE obj.type = :type AND obj.subtype = :subtype AND obj.moodleid <> :siteid";
+        $params = ['type' => 'group', 'subtype' => 'course', 'siteid' => SITEID];
+        $connectedcourseids = $DB->get_fieldset_sql($sql, $params);
+        if (empty($connectedcourseids)) {
+            return [];
+        }
+
+        $enabled = coursesyncutils::get_enabled_courses();
+        if ($enabled === true) {
+            return array_values(array_map('intval', $connectedcourseids));
+        }
+        if (is_array($enabled) && !empty($enabled)) {
+            return array_values(array_intersect(array_map('intval', $connectedcourseids), array_map('intval', $enabled)));
+        }
+
+        return [];
     }
 }

--- a/local/o365/lang/en/local_o365.php
+++ b/local/o365/lang/en/local_o365.php
@@ -976,6 +976,7 @@ $string['ucp_o365accountconnected'] = 'This Microsoft 365 account is already con
 $string['task_calendarsyncin'] = 'Sync Microsoft 365 events in to Moodle';
 $string['task_coursesync'] = 'Sync Moodle courses to Microsoft Teams';
 $string['task_coursemembershipsync'] = 'Sync Microsoft Teams owners and members to Moodle courses';
+$string['task_groupmembershipsync'] = 'Sync Moodle course owners and members to Microsoft 365 groups';
 $string['task_sds_sync'] = 'Sync with SDS';
 $string['task_syncusers'] = 'Sync users from Microsoft Entra ID';
 $string['task_syncusersphotostimezones'] = 'Sync user photos and timezones from Microsoft Entra ID';


### PR DESCRIPTION
- add_group_owners_and_members_to_group(): a single invalid user reference no longer causes Graph to reject the whole chunk of 20. Missing users are dropped and the request retried; if the bulk add still fails, fall back to adding users individually, tolerating "already exists" and recording users that no longer exist.
- main::__construct(): initialise the $SESSION->o365_* tracking arrays so the missing-user / missing-group recovery in the bulk add works when called from adhoc tasks and observers, not only from the coursesync scheduled task.
- get_user_group_role_by_moodle_ids(): consider role assignments inherited from parent contexts, matching the capability resolution used by the bulk owner/member lookup, so the per-user and bulk syncs agree. Also fix the excluderoleid filter, which unset by array index instead of by role id.
- groupmembershipsync: process sync-enabled connected courses in bounded batches, queueing a follow-up task for the remainder, with per-course error isolation, so large sites no longer time out and restart from the beginning. Add a task name string.