### PR TITLE
local_o365: suspend connected accounts with no stored Microsoft link

### DIFF
--- a/local/o365/classes/adminsetting/usersyncoptions.php
+++ b/local/o365/classes/adminsetting/usersyncoptions.php
@@ -58,6 +58,7 @@ class usersyncoptions extends admin_setting_configmulticheckbox {
             'reenable' => new \lang_string('settings_usersync_reenable', 'local_o365'),
             'disabledsyncsuspend' => new \lang_string('settings_usersync_disabledsyncsuspend', 'local_o365'),
             'disabledsyncreenable' => new \lang_string('settings_usersync_disabledsyncreenable', 'local_o365'),
+            'suspendnolink' => new \lang_string('settings_usersync_suspendnolink', 'local_o365'),
             'match' => new \lang_string('settings_usersync_match', 'local_o365'),
             'matchswitchauth' => new \lang_string('settings_usersync_matchswitchauth', 'local_o365'),
             'appassign' => new \lang_string('settings_usersync_appassign', 'local_o365'),
@@ -104,7 +105,8 @@ class usersyncoptions extends admin_setting_configmulticheckbox {
                 ],
                 'suspension' => [
                         'title' => new \lang_string('settings_usersync_suspension', 'local_o365'),
-                        'options' => ['suspend', 'delete', 'reenable', 'disabledsyncsuspend', 'disabledsyncreenable'],
+                        'options' => ['suspend', 'delete', 'reenable', 'disabledsyncsuspend', 'disabledsyncreenable',
+                                'suspendnolink'],
                 ],
                 'matching' => [
                         'title' => new \lang_string('settings_usersync_matching', 'local_o365'),
@@ -169,6 +171,8 @@ class usersyncoptions extends admin_setting_configmulticheckbox {
                 var deleteChk = document.getElementById("' . $this->get_id() . '_delete");
                 var matchChk = document.getElementById("' . $this->get_id() . '_match");
                 var matchswitchauthChk = document.getElementById("' . $this->get_id() . '_matchswitchauth");
+                var disabledsuspendChk = document.getElementById("' . $this->get_id() . '_disabledsyncsuspend");
+                var suspendnolinkChk = document.getElementById("' . $this->get_id() . '_suspendnolink");
 
                 function updateDependencies() {
                     if (deleteChk) {
@@ -183,10 +187,19 @@ class usersyncoptions extends admin_setting_configmulticheckbox {
                             matchswitchauthChk.checked = false;
                         }
                     }
+                    if (suspendnolinkChk) {
+                        var suspendparent = suspendChk.checked ||
+                            (disabledsuspendChk && disabledsuspendChk.checked);
+                        suspendnolinkChk.disabled = !suspendparent;
+                        if (!suspendparent && suspendnolinkChk.checked) {
+                            suspendnolinkChk.checked = false;
+                        }
+                    }
                 }
 
                 if (suspendChk) suspendChk.addEventListener("change", updateDependencies);
                 if (matchChk) matchChk.addEventListener("change", updateDependencies);
+                if (disabledsuspendChk) disabledsuspendChk.addEventListener("change", updateDependencies);
                 updateDependencies();
             });
         </script>';
@@ -213,6 +226,11 @@ class usersyncoptions extends admin_setting_configmulticheckbox {
         // Option 'delete' can only be set if option 'suspend' is checked.
         if (!isset($data['suspend']) && isset($data['delete'])) {
             unset($data['delete']);
+        }
+
+        // Option 'suspendnolink' can only be set if 'suspend' or 'disabledsyncsuspend' is checked.
+        if (!isset($data['suspend']) && !isset($data['disabledsyncsuspend']) && isset($data['suspendnolink'])) {
+            unset($data['suspendnolink']);
         }
 
         // Option 'matchswitchauth' can only be set if option 'match' is checked.

--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -697,12 +697,13 @@ class main {
      * process_users_batched() with the appropriate callback instead.
      *
      * @param callable $callback Function to call for each batch of users. Receives array of users as parameter.
+     * @param array $extraselect Additional Graph user resource fields to include in the query's $select.
      * @return int Total number of users processed
      * @throws moodle_exception
      */
-    public function process_users_minimal_batched(callable $callback): int {
+    public function process_users_minimal_batched(callable $callback, array $extraselect = []): int {
         $apiclient = $this->construct_user_api();
-        return $apiclient->process_users_minimal_batched($callback);
+        return $apiclient->process_users_minimal_batched($callback, $extraselect);
     }
 
     /**
@@ -1342,6 +1343,35 @@ class main {
     public static function sync_option_enabled($option) {
         $options = static::get_sync_options();
         return isset($options[$option]);
+    }
+
+    /**
+     * Get the Microsoft Graph user resource field whose value is stored as the Moodle username, based on the configured
+     * auth_oidc binding username claim.
+     *
+     * Only returns a field when the Moodle username can be matched reliably against a single Graph user attribute, i.e.
+     * when the admin has explicitly selected one of upn, oid, email or samaccountname. Returns null for:
+     *  - "auto" - the effective claim is decided per token at login time and can differ between users;
+     *  - sub, unique_name, preferred_username - not Graph user resource fields;
+     *  - a custom claim name.
+     * In those cases the Moodle username cannot be resolved back to a single Entra ID account.
+     *
+     * @return string|null The Graph field name, or null if the binding claim cannot be mapped to one.
+     */
+    public static function get_binding_graph_field(): ?string {
+        $claim = auth_oidc_get_binding_username_claim();
+        switch ($claim) {
+            case 'upn':
+                return 'userPrincipalName';
+            case 'oid':
+                return 'id';
+            case 'email':
+                return 'mail';
+            case 'samaccountname':
+                return 'onPremisesSamAccountName';
+            default:
+                return null;
+        }
     }
 
     /**
@@ -2361,11 +2391,14 @@ class main {
             $dbman->drop_table($table);
         }
 
-        // Create temp table with objectid and accountenabled status.
+        // Create temp table with objectid, accountenabled status, and the binding username claim value (used to match
+        // Moodle accounts that have no local_o365_objects record - see suspend_unlinked_users_from_temp_table()).
         $table = new \xmldb_table($tempname);
         $table->add_field('objectid', XMLDB_TYPE_CHAR, 255, null, XMLDB_NOTNULL, null, null);
         $table->add_field('accountenabled', XMLDB_TYPE_INTEGER, 1, null, XMLDB_NOTNULL, null, 0);
+        $table->add_field('bindingvalue', XMLDB_TYPE_CHAR, 255, null, null, null, null);
         $table->add_index('objectid', XMLDB_INDEX_UNIQUE, ['objectid']);
+        $table->add_index('bindingvalue', XMLDB_INDEX_NOTUNIQUE, ['bindingvalue']);
 
         $dbman->create_temp_table($table);
 
@@ -2408,26 +2441,45 @@ class main {
 
         $apiclient = $this->construct_user_api();
         $insertcount = 0;
+        $bindingcount = 0;
+
+        // Also fetch the field that maps to the Moodle username, so accounts without a local_o365_objects record can be
+        // matched to Entra. Null means the configured binding claim is not a queryable Graph field.
+        $bindingfield = self::get_binding_graph_field();
+        $extraselect = ($bindingfield !== null && $bindingfield !== 'id') ? [$bindingfield] : [];
 
         // Intentionally unfiltered — see method docblock for rationale.
-        $apiclient->process_users_minimal_batched(function (array $entrabatch) use ($DB, $temptablename, &$insertcount) {
-            $records = [];
-            foreach ($entrabatch as $user) {
-                if (!empty($user['id'])) {
-                    $record = new \stdClass();
-                    $record->objectid = $user['id'];
-                    $record->accountenabled = ($user['accountEnabled'] ?? false) ? 1 : 0;
-                    $records[] = $record;
+        $apiclient->process_users_minimal_batched(
+            function (array $entrabatch) use ($DB, $temptablename, &$insertcount, &$bindingcount, $bindingfield) {
+                $records = [];
+                foreach ($entrabatch as $user) {
+                    if (!empty($user['id'])) {
+                        $record = new \stdClass();
+                        $record->objectid = $user['id'];
+                        $record->accountenabled = ($user['accountEnabled'] ?? false) ? 1 : 0;
+                        $record->bindingvalue = null;
+                        if ($bindingfield === 'id') {
+                            $record->bindingvalue = core_text::strtolower($user['id']);
+                        } else if ($bindingfield !== null && !empty($user[$bindingfield])) {
+                            $record->bindingvalue = core_text::strtolower($user[$bindingfield]);
+                        }
+                        if ($record->bindingvalue !== null) {
+                            $bindingcount++;
+                        }
+                        $records[] = $record;
+                    }
                 }
-            }
 
-            if (!empty($records)) {
-                $DB->insert_records($temptablename, $records);
-                $insertcount += count($records);
-            }
-        });
+                if (!empty($records)) {
+                    $DB->insert_records($temptablename, $records);
+                    $insertcount += count($records);
+                }
+            },
+            $extraselect
+        );
 
-        $this->mtrace('Inserted ' . $insertcount . ' Entra users into temp table.');
+        $this->mtrace('Inserted ' . $insertcount . ' Entra users into temp table (' . $bindingcount .
+            ' with a usable binding value).');
     }
 
     /**
@@ -2443,6 +2495,8 @@ class main {
      * @param bool $dodisabledsyncsuspend Whether to suspend users whose Entra account is disabled.
      * @param bool $dodisabledsyncreenable Whether to reenable users whose Entra account is (re-)enabled, and whether
      *                                     to require accountEnabled=true before reenabling via $doreenable.
+     * @param bool $dosuspendunlinked Whether to also suspend oidc accounts that have no local_o365_objects record,
+     *                                matched to Entra by the binding username claim. Suspend only, never delete.
      *
      * @return array [$reenabled, $suspended, $deleted] counts.
      */
@@ -2452,7 +2506,8 @@ class main {
         bool $dosuspend,
         bool $dodelete,
         bool $dodisabledsyncsuspend,
-        bool $dodisabledsyncreenable
+        bool $dodisabledsyncreenable,
+        bool $dosuspendunlinked = false
     ): array {
         global $CFG, $DB;
 
@@ -2556,7 +2611,128 @@ class main {
             $this->update_users_suspended(1, $userstosuspend);
         }
 
+        // Handle oidc accounts that have no local_o365_objects record (never synced, or the record was removed). These
+        // are invisible to the query above because it inner-joins local_o365_objects. Suspend only - never delete.
+        if ($dosuspendunlinked && ($dosuspend || $dodisabledsyncsuspend)) {
+            $suspended += $this->suspend_unlinked_users_from_temp_table($temptablename, $dosuspend, $dodisabledsyncsuspend);
+        }
+
         return [$reenabled, $suspended, $deleted];
+    }
+
+    /**
+     * Suspend oidc Moodle accounts that have no local_o365_objects record, by matching the Moodle username against the
+     * Entra binding username claim value stored in the temp table.
+     *
+     * These accounts carry no stored Entra object id, so this method never deletes (the soft-delete retention check in
+     * process_user_status_from_temp_table() cannot be performed) and never re-enables. It only suspends:
+     *  - accounts whose binding value is not present in Entra at all (treated as deleted), when $dosuspend is on;
+     *  - accounts found in Entra but with accountEnabled = false, when $dodisabledsyncsuspend is on.
+     *
+     * Matching accounts that are already suspended are reported separately (no action taken) so the admin gets a full
+     * picture of the unlinked accounts that are gone from / disabled in Entra ID.
+     *
+     * Guest-style usernames are skipped. If the configured binding claim cannot be mapped to a Graph field, or the temp
+     * table holds no binding values at all, this is a no-op (protects against mass suspension from a misconfiguration).
+     *
+     * @param string $temptablename The name of the temporary table with Entra users.
+     * @param bool $dosuspend Whether to suspend accounts not found in Entra.
+     * @param bool $dodisabledsyncsuspend Whether to suspend accounts found in Entra but disabled.
+     * @return int Number of accounts newly suspended.
+     */
+    private function suspend_unlinked_users_from_temp_table(
+        string $temptablename,
+        bool $dosuspend,
+        bool $dodisabledsyncsuspend
+    ): int {
+        global $CFG, $DB;
+
+        if (self::get_binding_graph_field() === null) {
+            $this->mtrace('Skipping accounts with no Microsoft link: the binding username claim is not a Graph field.');
+            return 0;
+        }
+
+        if (!$DB->record_exists_select($temptablename, 'bindingvalue IS NOT NULL')) {
+            $this->mtrace('Skipping accounts with no Microsoft link: no binding values were returned from Entra ID.');
+            return 0;
+        }
+
+        // Group by user: a binding value can (rarely) match more than one Entra account. Treat the user as present in
+        // Entra if any row matched, and as enabled if any matching account is enabled (conservative - avoids suspending
+        // someone who still has an active account).
+        $sql = 'SELECT u.id, u.username, u.suspended,
+                       MAX(CASE WHEN etmp.bindingvalue IS NOT NULL THEN 1 ELSE 0 END) AS isinentra,
+                       MAX(COALESCE(etmp.accountenabled, 0)) AS accountenabled
+                  FROM {user} u
+             LEFT JOIN {local_o365_objects} obj ON obj.type = ? AND obj.moodleid = u.id
+             LEFT JOIN {' . $temptablename . '} etmp ON etmp.bindingvalue = LOWER(u.username)
+                 WHERE u.mnethostid = ?
+                   AND u.deleted = ?
+                   AND u.auth = ?
+                   AND obj.id IS NULL
+              GROUP BY u.id, u.username, u.suspended';
+        $params = ['user', $CFG->mnet_localhost_id, '0', 'oidc'];
+
+        $rs = $DB->get_recordset_sql($sql, $params);
+
+        $count = 0;
+        $tosuspend = [];
+        $alreadysuspendedcount = 0;
+        $alreadysuspendedsample = [];
+        $samplecap = 50;
+        foreach ($rs as $user) {
+            // Skip guest-style accounts - their username rarely maps cleanly to a binding value.
+            if (stripos($user->username, '_ext_') !== false || stripos($user->username, '#ext#') !== false) {
+                continue;
+            }
+
+            $reason = null;
+            if (!$user->isinentra && $dosuspend) {
+                $reason = 'not found in Entra ID';
+            } else if ($user->isinentra && !$user->accountenabled && $dodisabledsyncsuspend) {
+                $reason = 'disabled in Entra ID';
+            }
+
+            if ($reason === null) {
+                continue;
+            }
+
+            if ($user->suspended) {
+                // Already suspended - report only, do not touch. Keep a capped sample rather than the whole list.
+                $alreadysuspendedcount++;
+                if (count($alreadysuspendedsample) < $samplecap) {
+                    $alreadysuspendedsample[] = $user->username . ' (' . $reason . ')';
+                }
+                continue;
+            }
+
+            $tosuspend[] = $user->id;
+            $this->mtrace('Suspended ' . $user->username . ' (' . $reason . '; no stored Microsoft link)');
+            $count++;
+
+            if (count($tosuspend) >= 500) {
+                $this->update_users_suspended(1, $tosuspend);
+                $tosuspend = [];
+            }
+        }
+        $rs->close();
+
+        if (!empty($tosuspend)) {
+            $this->update_users_suspended(1, $tosuspend);
+        }
+
+        if ($alreadysuspendedcount > 0) {
+            $this->mtrace($alreadysuspendedcount . ' account(s) with no stored Microsoft link are missing from or ' .
+                'disabled in Entra ID but are already suspended (no action taken):');
+            foreach ($alreadysuspendedsample as $line) {
+                $this->mtrace('  ' . $line);
+            }
+            if ($alreadysuspendedcount > count($alreadysuspendedsample)) {
+                $this->mtrace('  ... and ' . ($alreadysuspendedcount - count($alreadysuspendedsample)) . ' more.');
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/local/o365/classes/rest/unified.php
+++ b/local/o365/classes/rest/unified.php
@@ -1313,16 +1313,18 @@ class unified extends o365api {
     }
 
     /**
-     * Process users in batches with minimal fields (id and accountEnabled only).
+     * Process users in batches with minimal fields (id and accountEnabled, plus any extra fields requested).
      * This method is optimized for suspend/reenable operations that only need user IDs.
      *
      * @param callable $callback Function to call for each batch of users. Receives array of users as parameter.
+     * @param array $extraselect Additional Graph user resource fields to include in $select (e.g. 'userPrincipalName').
      * @return int Total number of users processed
      * @throws moodle_exception
      */
-    public function process_users_minimal_batched(callable $callback): int {
+    public function process_users_minimal_batched(callable $callback, array $extraselect = []): int {
+        $selectfields = array_values(array_unique(array_merge(['id', 'accountEnabled'], $extraselect)));
         $odataqueries = [
-            '$select' => 'id,accountEnabled',
+            '$select' => implode(',', $selectfields),
             '$top'    => (string)self::GRAPH_API_BATCH_SIZE,
         ];
 

--- a/local/o365/classes/task/userenabledstatussync.php
+++ b/local/o365/classes/task/userenabledstatussync.php
@@ -62,6 +62,7 @@ class userenabledstatussync extends scheduled_task {
         $dodelete = main::sync_option_enabled('delete');
         $dodisabledsyncsuspend = main::sync_option_enabled('disabledsyncsuspend');
         $dodisabledsyncreenable = main::sync_option_enabled('disabledsyncreenable');
+        $dosuspendunlinked = main::sync_option_enabled('suspendnolink');
 
         $this->mtrace('Status sync options:');
         $this->mtrace('Suspend (deleted from Entra ID): ' . ($dosuspend ? 'enabled' : 'disabled'), 1);
@@ -69,6 +70,8 @@ class userenabledstatussync extends scheduled_task {
         $this->mtrace('Delete: ' . ($dodelete ? 'enabled' : 'disabled'), 1);
         $this->mtrace('Suspend (disabled in Entra ID): ' . ($dodisabledsyncsuspend ? 'enabled' : 'disabled'), 1);
         $this->mtrace('Re-enable (enabled in Entra ID): ' . ($dodisabledsyncreenable ? 'enabled' : 'disabled'), 1);
+        $this->mtrace('Suspend accounts with no stored Microsoft link: ' .
+            ($dosuspendunlinked ? 'enabled' : 'disabled'), 1);
     }
 
     /**
@@ -86,6 +89,7 @@ class userenabledstatussync extends scheduled_task {
         $dodelete = main::sync_option_enabled('delete');
         $dodisabledsyncsuspend = main::sync_option_enabled('disabledsyncsuspend');
         $dodisabledsyncreenable = main::sync_option_enabled('disabledsyncreenable');
+        $dosuspendunlinked = main::sync_option_enabled('suspendnolink');
 
         if (!$dosuspend && !$doreenable && !$dodisabledsyncsuspend && !$dodisabledsyncreenable) {
             $this->mtrace('User suspension and re-enable disabled. Nothing to do.');
@@ -174,7 +178,8 @@ class userenabledstatussync extends scheduled_task {
                 $dosuspend,
                 $dodelete,
                 $dodisabledsyncsuspend,
-                $dodisabledsyncreenable
+                $dodisabledsyncreenable,
+                $dosuspendunlinked
             );
 
             if ($totalreenabled > 0) {

--- a/local/o365/lang/en/local_o365.php
+++ b/local/o365/lang/en/local_o365.php
@@ -148,6 +148,7 @@ $string['settings_usersync_delete'] = 'Delete previously synced accounts in Mood
 $string['settings_usersync_reenable'] = 'Re-enable suspended accounts for users in Microsoft Entra ID';
 $string['settings_usersync_disabledsyncsuspend'] = 'Suspend accounts in Moodle when disabled in Microsoft Entra ID';
 $string['settings_usersync_disabledsyncreenable'] = 'Re-enable accounts in Moodle when re-enabled in Microsoft Entra ID';
+$string['settings_usersync_suspendnolink'] = 'Suspend connected accounts that have no stored Microsoft link when they are deleted from or disabled in Microsoft Entra ID';
 $string['settings_usersync_match'] = 'Match preexisting Moodle users with same-named accounts in Microsoft Entra ID';
 $string['settings_usersync_matchswitchauth'] = 'Switch matched users to Microsoft 365 (OpenID Connect) authentication';
 $string['settings_usersync_appassign'] = 'Assign users to application during sync';
@@ -1025,6 +1026,14 @@ $string['help_user_disabledsyncsuspend'] = 'Suspend Accounts On Disable Help';
 $string['help_user_disabledsyncsuspend_help'] = 'This will suspend users in Moodle if their connected accounts in Microsoft Entra ID are prevented from logging in (disabled), without changing whether they are automatically re-enabled if their Microsoft Entra ID account is enabled again. Use the "Re-enable accounts in Moodle when re-enabled in Microsoft Entra ID" option below to control that separately.';
 $string['help_user_disabledsyncreenable'] = 'Re-enable Accounts On Enable Help';
 $string['help_user_disabledsyncreenable_help'] = 'This will unsuspend suspended users in Moodle if their connected accounts in Microsoft Entra ID are allowed to log in (enabled) again.';
+$string['help_user_suspendnolink'] = 'Suspend Accounts With No Microsoft Link Help';
+$string['help_user_suspendnolink_help'] = 'Normally the suspend/disable options above only act on accounts that have a stored Microsoft Entra ID object record (created when the account was synced or connected). Some OpenID Connect accounts have no such record - for example they connected before the Microsoft Graph API was configured, or the record was removed by a disconnect or a "clear matched users" action. This option makes the status task also check those accounts, matching the Moodle username against the configured binding username claim value in Entra ID.
+
+Matched accounts that are missing from Entra ID, or disabled there, are <strong>suspended only</strong>: they are never deleted (without a stored object ID, the Entra ID soft-delete retention period cannot be checked) and are never automatically re-enabled. Guest accounts are skipped.
+
+This option only works when the OpenID Connect binding username claim is set to a specific field that can be looked up in Entra ID - "upn", "oid", "email" or "samaccountname". With "auto" (where the effective claim is chosen per login and can differ between users) or any other claim, the Moodle username cannot be reliably matched to a single account, and this option does nothing.
+
+Review your suspended users after the first run: an account manually switched to this authentication method that was never a real Entra ID user will be suspended by this option.';
 $string['help_user_match'] = 'Match Accounts Help';
 $string['help_user_match_help'] = 'This will look at each user in the linked Microsoft Entra ID and try to match them with a user in Moodle. This match is based on Microsoft Entra ID UPN and Moodle username. Matches are case-insensitive and ignore the domain part of Microsoft Entra ID UPN. For example, "BoB.SmiTh" in Moodle would match "bob.smith@example.onmicrosoft.com". Users who are matched will have their Moodle and Microsoft Entra ID accounts connected and will be able to use all Microsoft 365 and Moodle integration features. The user\'s authentication method will not change unless the setting below is enabled.';
 $string['help_user_matchswitchauth'] = 'Switch Matched Accounts Help';

--- a/local/o365/tests/usersync_test.php
+++ b/local/o365/tests/usersync_test.php
@@ -675,6 +675,191 @@ final class usersync_test extends advanced_testcase {
     }
 
     /**
+     * Test that 'suspendnolink' suspends oidc accounts with no local_o365_objects record, matching by username, and
+     * leaves alone accounts that are still present and enabled in Entra as well as non-oidc accounts.
+     *
+     * @covers \local_o365\feature\usersync\main::process_user_status_from_temp_table
+     * @covers \local_o365\feature\usersync\main::suspend_unlinked_users_from_temp_table
+     */
+    public function test_process_user_status_suspend_unlinked(): void {
+        global $DB;
+
+        // Binding username claim must be a specific resolvable field for unlinked matching to run.
+        set_config('bindingusernameclaim', 'upn', 'auth_oidc');
+
+        $generator = $this->getDataGenerator();
+        // Orphan oidc account (no local_o365_objects record) that is missing from Entra.
+        $deletedorphan = $generator->create_user(['auth' => 'oidc', 'suspended' => 0]);
+        // Orphan oidc account still present and enabled in Entra - must be left alone.
+        $liveorphan = $generator->create_user(['auth' => 'oidc', 'suspended' => 0]);
+        // Non-oidc account whose username matches an Entra account - must never be touched.
+        $manualuser = $generator->create_user(['auth' => 'manual', 'suspended' => 0]);
+        // Orphan missing from Entra but already suspended - reported only, not re-counted.
+        $suspendedorphan = $generator->create_user(['auth' => 'oidc', 'suspended' => 1]);
+
+        $usersync = new main();
+        $temptablename = $usersync->create_entra_users_temp_table();
+
+        try {
+            $DB->insert_records($temptablename, [
+                (object) ['objectid' => 'obj-live', 'accountenabled' => 1, 'bindingvalue' => $liveorphan->username],
+                (object) ['objectid' => 'obj-manual', 'accountenabled' => 1, 'bindingvalue' => $manualuser->username],
+            ]);
+
+            [$reenabled, $suspended, $deleted] = $usersync->process_user_status_from_temp_table(
+                $temptablename,
+                false, // Do not re-enable.
+                true, // Suspend deleted users.
+                false, // Do not delete.
+                false, // Do not suspend on disabled accounts.
+                false, // Do not re-enable users enabled in Entra.
+                true   // Suspend unlinked accounts.
+            );
+
+            $this->assertEquals(0, $reenabled);
+            $this->assertEquals(1, $suspended, 'Only the not-yet-suspended orphan should be counted.');
+            $this->assertEquals(0, $deleted);
+
+            $this->assertEquals(
+                1,
+                $DB->get_field('user', 'suspended', ['id' => $deletedorphan->id]),
+                'Unlinked oidc account missing from Entra should be suspended.'
+            );
+            $this->assertEquals(
+                0,
+                $DB->get_field('user', 'suspended', ['id' => $liveorphan->id]),
+                'Unlinked oidc account still present and enabled in Entra should be left alone.'
+            );
+            $this->assertEquals(
+                0,
+                $DB->get_field('user', 'suspended', ['id' => $manualuser->id]),
+                'Non-oidc account should never be touched.'
+            );
+            $this->assertEquals(
+                1,
+                $DB->get_field('user', 'suspended', ['id' => $suspendedorphan->id]),
+                'Already-suspended orphan stays suspended and is not re-counted.'
+            );
+        } finally {
+            $usersync->drop_entra_users_temp_table($temptablename);
+        }
+    }
+
+    /**
+     * Test the guards on 'suspendnolink': it does nothing when the option is off, skips guest-style usernames, and
+     * only suspends matched-but-disabled accounts when 'disabledsyncsuspend' is on.
+     *
+     * @covers \local_o365\feature\usersync\main::process_user_status_from_temp_table
+     * @covers \local_o365\feature\usersync\main::suspend_unlinked_users_from_temp_table
+     */
+    public function test_process_user_status_suspend_unlinked_guards(): void {
+        global $DB;
+
+        set_config('bindingusernameclaim', 'upn', 'auth_oidc');
+
+        $generator = $this->getDataGenerator();
+        $orphan = $generator->create_user(['auth' => 'oidc', 'suspended' => 0]);
+        $guestorphan = $generator->create_user(['auth' => 'oidc', 'suspended' => 0, 'username' => 'guest_ext_1']);
+        $disabledorphan = $generator->create_user(['auth' => 'oidc', 'suspended' => 0]);
+
+        $usersync = new main();
+
+        // Option off - nothing happens even though the orphan is missing from Entra.
+        $temptablename = $usersync->create_entra_users_temp_table();
+        try {
+            $DB->insert_records($temptablename, [
+                (object) ['objectid' => 'obj-x', 'accountenabled' => 1, 'bindingvalue' => 'someone-else'],
+            ]);
+            $usersync->process_user_status_from_temp_table($temptablename, false, true, false, false, false, false);
+            $this->assertEquals(
+                0,
+                $DB->get_field('user', 'suspended', ['id' => $orphan->id]),
+                'Nothing should happen while suspendnolink is off.'
+            );
+        } finally {
+            $usersync->drop_entra_users_temp_table($temptablename);
+        }
+
+        // Option on: guest-style username is skipped; disabled match only suspended with disabledsyncsuspend.
+        $temptablename = $usersync->create_entra_users_temp_table();
+        try {
+            $DB->insert_records($temptablename, [
+                (object) ['objectid' => 'obj-disabled', 'accountenabled' => 0, 'bindingvalue' => $disabledorphan->username],
+                (object) ['objectid' => 'obj-guest', 'accountenabled' => 0, 'bindingvalue' => 'guest_ext_1'],
+            ]);
+            [, $suspended] = $usersync->process_user_status_from_temp_table(
+                $temptablename,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true
+            );
+
+            $this->assertEquals(2, $suspended);
+            $this->assertEquals(
+                1,
+                $DB->get_field('user', 'suspended', ['id' => $orphan->id]),
+                'Orphan missing from Entra should be suspended.'
+            );
+            $this->assertEquals(
+                1,
+                $DB->get_field('user', 'suspended', ['id' => $disabledorphan->id]),
+                'Orphan disabled in Entra should be suspended when disabledsyncsuspend is on.'
+            );
+            $this->assertEquals(
+                0,
+                $DB->get_field('user', 'suspended', ['id' => $guestorphan->id]),
+                'Guest-style username should be skipped.'
+            );
+        } finally {
+            $usersync->drop_entra_users_temp_table($temptablename);
+        }
+    }
+
+    /**
+     * Test that 'suspendnolink' does nothing when the binding username claim is "auto" (its effective claim is decided
+     * per login and can differ between users, so the Moodle username cannot be reliably matched to one Entra account).
+     *
+     * @covers \local_o365\feature\usersync\main::suspend_unlinked_users_from_temp_table
+     * @covers \local_o365\feature\usersync\main::get_binding_graph_field
+     */
+    public function test_process_user_status_suspend_unlinked_requires_specific_claim(): void {
+        global $DB;
+
+        set_config('bindingusernameclaim', 'auto', 'auth_oidc');
+
+        $orphan = $this->getDataGenerator()->create_user(['auth' => 'oidc', 'suspended' => 0]);
+
+        $usersync = new main();
+        $temptablename = $usersync->create_entra_users_temp_table();
+        try {
+            $DB->insert_records($temptablename, [
+                (object) ['objectid' => 'obj-x', 'accountenabled' => 1, 'bindingvalue' => 'someone-else'],
+            ]);
+            [, $suspended] = $usersync->process_user_status_from_temp_table(
+                $temptablename,
+                false,
+                true,
+                false,
+                false,
+                false,
+                true
+            );
+
+            $this->assertEquals(0, $suspended);
+            $this->assertEquals(
+                0,
+                $DB->get_field('user', 'suspended', ['id' => $orphan->id]),
+                'Unlinked matching must not run when the binding claim is "auto".'
+            );
+        } finally {
+            $usersync->drop_entra_users_temp_table($temptablename);
+        }
+    }
+
+    /**
      * Test that 'disabledsyncreenable' independently re-enables a suspended user present in Entra with
      * accountEnabled=true, without needing 'reenable' enabled, and leaves a still-disabled user suspended.
      *


### PR DESCRIPTION
The "Suspend/re-enable/delete users based on Microsoft Entra ID status" task only ever looked at Moodle users that have a local_o365_objects record, because process_user_status_from_temp_table() inner-joins that table. An oidc account whose object record was never created (for example it connected before the Graph API was configured) or was later removed (a disconnect, or a "clear matched users" action) is invisible to the task and is never suspended when its Entra ID account is deleted or disabled.

Add a new, off-by-default "Suspend connected accounts that have no stored Microsoft link ..." user sync option, dependent on one of the suspend options. When enabled, the status task also checks oidc accounts with no local_o365_objects record, matching the Moodle username against the configured binding username claim value in Entra ID (userPrincipalName, id, mail or onPremisesSamAccountName; other claims cannot be resolved and are skipped). Matched accounts that are missing from or disabled in Entra ID are suspended only - never deleted (without a stored object id the soft-delete retention check cannot be performed) and never re-enabled. Guest-style usernames are skipped, and the pass is a no-op when the binding claim is unusable or the temp table returned no binding values, to guard against mass suspension from a misconfiguration. Matched accounts that are already suspended are reported separately, without being touched.

The status temp table gains a bindingvalue column, and process_users_minimal_batched() takes an optional list of extra Graph fields to select.