### PR TITLE
local_o365: log why user sync skips Entra ID users with no Moodle account

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -1650,7 +1650,7 @@ class main {
                 !isset($existingusers[$entraiduser['convertedidentifier']])
             ) {
                 // Check if the user has been renamed.
-                $syncnewuser = array_key_exists('create', $usersyncsettings);
+                $renamewashandled = false;
                 if (
                     isset($entraiduser['id']) && $entraiduser['id'] &&
                     $existingusermatching = ($this->o365objectsbyobjectid[$entraiduser['id']] ?? null)
@@ -1660,8 +1660,8 @@ class main {
 
                     $renamedmoodleuser = $this->fullusersbymoodleid[$existingusermatching->moodleid] ?? null;
                     if ($renamedmoodleuser) {
+                        $renamewashandled = true;
                         $this->mtrace('The user has been renamed in Microsoft...');
-                        $syncnewuser = false;
 
                         if ($supportuseridentifierchangeconfig == 1) {
                             // Check if manually matched users, who shouldn't be renamed.
@@ -1744,7 +1744,11 @@ class main {
                     }
                 }
 
-                if ($syncnewuser) {
+                if (!$renamewashandled) {
+                    // Not handled as a rename of a previously connected user. Hand off to sync_new_user(), which
+                    // creates the Moodle account when "Create accounts in Moodle" is enabled and otherwise logs why
+                    // the user is skipped. Previously this branch was skipped entirely when account creation was
+                    // disabled, leaving the sync output silent for Entra ID users with no linked Moodle account.
                     $this->sync_new_user(
                         $usersyncsettings,
                         $entraiduser,


### PR DESCRIPTION
When "Create accounts in Moodle" is disabled, sync_users() skipped Microsoft Entra ID users that have no linked Moodle account without emitting any output, so the task log showed only "Syncing user <upn>" followed by nothing.

Route those users through sync_new_user() regardless of the create option (it already returns early, logging "User doesn't exist in Moodle" and "Not creating a Moodle user because that sync option is disabled.", when creation is off). A previously connected user renamed in Microsoft is still handled by the rename branch and not passed on. No change to which accounts are created or updated.