### PR TITLE
auth_oidc: clear stored OIDC tokens on client ID change

### DIFF
--- a/auth/oidc/classes/observers.php
+++ b/auth/oidc/classes/observers.php
@@ -26,6 +26,7 @@
 namespace auth_oidc;
 
 use auth_oidc\loginflow\authcode;
+use core\event\config_log_created;
 use core\event\user_deleted;
 use core\event\user_loggedout;
 
@@ -66,6 +67,29 @@ class observers {
         }
 
         (new authcode())->clear_csrf_cookie();
+
+        return true;
+    }
+
+    /**
+     * Handle config_log_created event - react to changes of the plugin's application configuration.
+     *
+     * When the configured client (application) ID changes, the plugin is authenticating against a
+     * different application registration, so every stored OIDC token is bound to the old application
+     * and can no longer be used. Clear the token table so affected users re-authenticate on their
+     * next login and fresh tokens are stored.
+     *
+     * @param config_log_created $event The triggered event.
+     * @return bool Success/Failure.
+     */
+    public static function handle_config_log_created(config_log_created $event) {
+        global $DB;
+
+        $other = $event->get_data()['other'] ?? [];
+
+        if (($other['plugin'] ?? '') === 'auth_oidc' && ($other['name'] ?? '') === 'clientid') {
+            $DB->delete_records('auth_oidc_token');
+        }
 
         return true;
     }

--- a/auth/oidc/db/events.php
+++ b/auth/oidc/db/events.php
@@ -38,4 +38,10 @@ $observers = [
         'priority' => 200,
         'internal' => false,
     ],
+    [
+        'eventname' => '\core\event\config_log_created',
+        'callback' => '\auth_oidc\observers::handle_config_log_created',
+        'priority' => 200,
+        'internal' => true,
+    ],
 ];

--- a/auth/oidc/tests/observers_test.php
+++ b/auth/oidc/tests/observers_test.php
@@ -18,6 +18,7 @@ namespace auth_oidc;
 
 use advanced_testcase;
 use core\context\system;
+use core\event\config_log_created;
 use core\event\user_deleted;
 
 /**
@@ -134,5 +135,86 @@ final class observers_test extends advanced_testcase {
 
         // Verify still no token exists (nothing changed).
         $this->assertFalse($DB->record_exists('auth_oidc_token', ['userid' => $user->id]));
+    }
+
+    /**
+     * Insert an auth_oidc_token record for the given user, filling the required fields.
+     *
+     * @param int $userid The Moodle user id to attach the token to.
+     * @return int The id of the inserted record.
+     */
+    private function create_token(int $userid): int {
+        global $DB;
+        return $DB->insert_record('auth_oidc_token', [
+            'userid' => $userid,
+            'oidcuniqid' => 'oidcuniqid' . $userid,
+            'username' => 'username' . $userid,
+            'oidcusername' => 'oidcusername' . $userid,
+            'scope' => 'scope',
+            'tokenresource' => 'tokenresource',
+            'authcode' => 'authcode',
+            'token' => 'token',
+            'expiry' => time(),
+            'refreshtoken' => 'refreshtoken',
+            'idtoken' => 'idtoken',
+        ]);
+    }
+
+    /**
+     * Build a config_log_created event describing a changed configuration setting.
+     *
+     * @param string $name The config setting name.
+     * @param string $plugin The plugin the setting belongs to.
+     * @return config_log_created
+     */
+    private function make_config_event(string $name, string $plugin = 'auth_oidc'): config_log_created {
+        return config_log_created::create([
+            'objectid' => 1,
+            'context' => system::instance(),
+            'other' => [
+                'name' => $name,
+                'oldvalue' => 'oldvalue',
+                'value' => 'newvalue',
+                'plugin' => $plugin,
+            ],
+        ]);
+    }
+
+    /**
+     * All stored OIDC tokens are cleared when the client ID setting changes.
+     *
+     * @return void
+     * @covers ::handle_config_log_created
+     */
+    public function test_tokens_are_cleared_when_clientid_changes(): void {
+        global $DB;
+        $userone = $this->getDataGenerator()->create_user();
+        $usertwo = $this->getDataGenerator()->create_user();
+        $this->create_token($userone->id);
+        $this->create_token($usertwo->id);
+        $this->assertEquals(2, $DB->count_records('auth_oidc_token'));
+
+        $result = observers::handle_config_log_created($this->make_config_event('clientid'));
+
+        $this->assertTrue($result);
+        $this->assertEquals(0, $DB->count_records('auth_oidc_token'));
+    }
+
+    /**
+     * Stored OIDC tokens are left untouched when a setting other than auth_oidc's client ID changes.
+     *
+     * @return void
+     * @covers ::handle_config_log_created
+     */
+    public function test_tokens_are_kept_when_other_settings_change(): void {
+        global $DB;
+        $user = $this->getDataGenerator()->create_user();
+        $this->create_token($user->id);
+
+        // A different auth_oidc setting, and the client ID of a different plugin.
+        $this->assertTrue(observers::handle_config_log_created($this->make_config_event('clientsecret')));
+        $this->assertTrue(observers::handle_config_log_created($this->make_config_event('clientid', 'local_o365')));
+
+        $this->assertEquals(1, $DB->count_records('auth_oidc_token'));
     }
 }

--- a/auth/oidc/version.php
+++ b/auth/oidc/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026042001;
+$plugin->version = 2026042001.01;
 $plugin->requires = 2026042000;
 $plugin->release = '5.2.1';
 $plugin->component = 'auth_oidc';

--- a/local/o365/classes/observers.php
+++ b/local/o365/classes/observers.php
@@ -846,8 +846,7 @@ class observers {
                     // Clear local_o365_token table.
                     $DB->delete_records('local_o365_token');
 
-                    // Clear auth_oidc_token table.
-                    $DB->delete_records('auth_oidc_token');
+                    // The auth_oidc_token table is cleared by auth_oidc's own observer on this event.
 
                     // Clear local_o365_connections table.
                     $DB->delete_records('local_o365_connections');


### PR DESCRIPTION
auth_oidc now observes config_log_created and clears the auth_oidc_token table when auth_oidc/clientid changes: the stored tokens are bound to the previous application registration and cannot be used against the new one, so affected users must re-authenticate on their next login anyway.

Previously the token table was only cleared by local_o365's observer, so a site running auth_oidc without local_o365 kept stale tokens after a client ID change. Move that responsibility to auth_oidc and drop the auth_oidc_token deletion from local_o365 so the table has a single owner; local_o365 keeps clearing its own tables.