### PR TITLE
auth_oidc: don't migrate removed stock icons into an unrenderable custom icon

### DIFF
--- a/auth/oidc/classes/utils.php
+++ b/auth/oidc/classes/utils.php
@@ -312,24 +312,19 @@ class utils {
     }
 
     /**
-     * Migrate a site's selected stock icon to the custom icon setting if it used one of the
-     * icon choices that have been removed from the icon selector.
+     * Migrate a site's selected stock icon if it used one of the icon choices that have been
+     * removed from the icon selector.
      *
      * The 'auth_oidc/icon' setting stores a "component:pix" identifier. The set of stock
-     * choices has been reduced to a handful of icons relevant to this plugin; any site that had
-     * selected one of the removed choices (all generic core Moodle icons) needs that icon copied
-     * into the custom icon file area so the login page keeps showing the same image.
+     * choices has been reduced to a handful of icons relevant to this plugin. A removed choice
+     * that has a direct Microsoft-branded replacement is remapped to it; any other removed
+     * choice was a generic core Moodle icon with no plugin-specific meaning and is reset to the
+     * plugin's default icon.
      *
-     * Safe to call more than once: once a site has been migrated (or its 'icon' setting was
-     * never one of the removed choices), every subsequent call is a no-op, since the checks
-     * above always return early once either 'auth_oidc/icon' is empty/unset or
-     * 'auth_oidc/customicon' is populated. The file and config writes are wrapped in a
-     * delegated transaction so a failure partway through can't leave those two settings out of
-     * sync with each other, which is what the early-return checks rely on.
+     * Safe to call more than once: once a site's 'icon' setting is no longer one of the removed
+     * choices every subsequent call is a no-op.
      */
     public static function migrate_removed_icon_choices(): void {
-        global $CFG, $DB;
-
         $currenticon = get_config('auth_oidc', 'icon');
         if (empty($currenticon)) {
             return;
@@ -364,50 +359,58 @@ class utils {
             return;
         }
 
-        $parts = explode(':', $currenticon, 2);
-        if (count($parts) !== 2) {
+        // Every other removed choice was a generic core Moodle icon (a lock, an arrow, a
+        // person, ...) with no Microsoft-specific meaning. Core ships these as SVG only, and
+        // the custom icon file area deliberately rejects SVG (see
+        // AUTH_OIDC_CUSTOMICON_ALLOWED_EXTENSIONS in lib.php), so the original image cannot be
+        // preserved. Fall back to the plugin's default icon.
+        set_config('icon', 'auth_oidc:microsoft_365', 'auth_oidc');
+    }
+
+    /**
+     * Undo a custom login icon migration that produced an icon the login page cannot render.
+     *
+     * An earlier version of {@see self::migrate_removed_icon_choices()} copied the site's
+     * chosen core stock icon into the 'auth_oidc/customicon' file area. Core stock icons are
+     * SVG, which auth_oidc_initialize_customicon() refuses to publish to pix_plugins/ (see
+     * AUTH_OIDC_CUSTOMICON_ALLOWED_EXTENSIONS), so those sites are left with a 'customicon'
+     * setting that looks populated but shows an empty icon on the login page.
+     *
+     * This detects that state - a stored custom icon named 'migrated_*' whose extension is not
+     * one auth_oidc_initialize_customicon() can publish - clears it, removes any stale published
+     * file, and restores the default stock icon. It is a no-op on any other site.
+     */
+    public static function repair_failed_icon_migration(): void {
+        global $CFG, $DB;
+
+        require_once($CFG->dirroot . '/auth/oidc/lib.php');
+
+        $customicon = get_config('auth_oidc', 'customicon');
+        if (empty($customicon) || !preg_match('#^/migrated_.+\.([^.]+)$#', $customicon, $matches)) {
             return;
         }
-        [, $pix] = $parts;
-
-        $sourcefile = null;
-        $extension = null;
-        foreach (['svg', 'png', 'gif', 'jpg', 'jpeg'] as $candidateextension) {
-            $candidatefile = "{$CFG->dirroot}/pix/{$pix}.{$candidateextension}";
-            if (file_exists($candidatefile)) {
-                $sourcefile = $candidatefile;
-                $extension = $candidateextension;
-                break;
-            }
-        }
-        if ($sourcefile === null) {
-            // Can't locate the source image for the removed choice, so there is nothing to copy.
+        if (in_array(strtolower($matches[1]), AUTH_OIDC_CUSTOMICON_ALLOWED_EXTENSIONS, true)) {
+            // The migrated icon uses a publishable format, so it renders correctly. Leave it be.
             return;
         }
 
         $systemcontext = system::instance();
         $fs = get_file_storage();
-        $filename = 'migrated_' . clean_param(str_replace('/', '_', $pix), PARAM_FILE) . '.' . $extension;
-        $filerecord = [
-            'contextid' => $systemcontext->id,
-            'component' => 'auth_oidc',
-            'filearea' => 'customicon',
-            'itemid' => 0,
-            'filepath' => '/',
-            'filename' => $filename,
-        ];
 
-        // Wrapped in a transaction so a failure partway through (e.g. the file write succeeding
-        // but a config write failing) can't leave 'icon' and 'customicon' out of sync, which
-        // would break the early-return guards above on any later call.
+        // Config and file writes are wrapped together so a later call still sees a consistent
+        // state (both cleared, or neither) if this fails partway through.
         $transaction = $DB->start_delegated_transaction();
         $fs->delete_area_files($systemcontext->id, 'auth_oidc', 'customicon', 0);
-        $fs->create_file_from_pathname($filerecord, $sourcefile);
-        set_config('customicon', '/' . $filename, 'auth_oidc');
-        unset_config('icon', 'auth_oidc');
+        unset_config('customicon', 'auth_oidc');
+        set_config('icon', 'auth_oidc:microsoft_365', 'auth_oidc');
         $transaction->allow_commit();
 
-        require_once($CFG->dirroot . '/auth/oidc/lib.php');
-        auth_oidc_initialize_customicon('/' . $filename);
+        // Drop any icon that a previously-valid extension had published, then rebuild caches so
+        // the login page stops pointing at it.
+        $publishedicons = glob($CFG->dataroot . '/pix_plugins/auth/oidc/0/customicon.*');
+        foreach ($publishedicons ?: [] as $publishedicon) {
+            @unlink($publishedicon);
+        }
+        theme_reset_all_caches();
     }
 }

--- a/auth/oidc/db/upgrade.php
+++ b/auth/oidc/db/upgrade.php
@@ -674,5 +674,10 @@ function xmldb_auth_oidc_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025100602.08, 'auth', 'oidc');
     }
 
+    if ($oldversion < 2025100603.02) {
+        \auth_oidc\utils::repair_failed_icon_migration();
+        upgrade_plugin_savepoint(true, 2025100603.02, 'auth', 'oidc');
+    }
+
     return true;
 }

--- a/auth/oidc/lib.php
+++ b/auth/oidc/lib.php
@@ -276,6 +276,9 @@ function auth_oidc_initialize_customicon($filefullname) {
             // Unexpected/empty extension: don't create a weird or unvalidated file under
             // pix_plugins. The stale files for previously-valid extensions were already
             // removed above, so this leaves no custom icon in place.
+            debugging('auth_oidc: custom icon "' . $file->get_filename() . '" has unsupported extension "' . $extension .
+                '" and will not be shown on the login page. Supported extensions: ' .
+                implode(', ', AUTH_OIDC_CUSTOMICON_ALLOWED_EXTENSIONS) . '.', DEBUG_DEVELOPER);
             return false;
         }
 

--- a/auth/oidc/tests/utils_test.php
+++ b/auth/oidc/tests/utils_test.php
@@ -1,0 +1,174 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace auth_oidc;
+
+use advanced_testcase;
+use core\context\system;
+
+/**
+ * Unit tests for auth_oidc\utils.
+ *
+ * @package   auth_oidc
+ * @author    Lai Wei <lai.wei@enovation.ie>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2026 onwards Microsoft, Inc. (http://microsoft.com/)
+ * @group auth_oidc
+ * @group office365
+ */
+final class utils_test extends advanced_testcase {
+    /**
+     * Data provider for {@see self::test_migrate_removed_icon_choices()}.
+     *
+     * @return array
+     */
+    public static function migrate_removed_icon_choices_provider(): array {
+        return [
+            'unset icon is left unset' => [null, null],
+            'kept icon is left unchanged' => ['auth_oidc:openid', 'auth_oidc:openid'],
+            'branded removed icon is remapped' => ['auth_oidc:o365', 'auth_oidc:office_365'],
+            'legacy microsoft icon is remapped' => ['auth_oidc:microsoft', 'auth_oidc:microsoft_365'],
+            'copilot icon is remapped' => ['auth_oidc:microsoft_365_copilot', 'auth_oidc:microsoft_365'],
+            'removed core icon falls back to default' => ['moodle:t/lock', 'auth_oidc:microsoft_365'],
+            'unknown value falls back to default' => ['something:unexpected', 'auth_oidc:microsoft_365'],
+        ];
+    }
+
+    /**
+     * Test utils::migrate_removed_icon_choices().
+     *
+     * @dataProvider migrate_removed_icon_choices_provider
+     * @param string|null $icon Value stored in auth_oidc/icon before migration.
+     * @param string|null $expected Expected value of auth_oidc/icon after migration.
+     * @return void
+     * @covers \auth_oidc\utils::migrate_removed_icon_choices
+     */
+    public function test_migrate_removed_icon_choices(?string $icon, ?string $expected): void {
+        $this->resetAfterTest(true);
+
+        if ($icon === null) {
+            unset_config('icon', 'auth_oidc');
+        } else {
+            set_config('icon', $icon, 'auth_oidc');
+        }
+
+        utils::migrate_removed_icon_choices();
+
+        $this->assertSame($expected, get_config('auth_oidc', 'icon') ?: null);
+    }
+
+    /**
+     * A populated custom icon means the stock icon setting is not in play, so migration must
+     * not touch either setting.
+     *
+     * @return void
+     * @covers \auth_oidc\utils::migrate_removed_icon_choices
+     */
+    public function test_migrate_removed_icon_choices_skips_when_customicon_set(): void {
+        $this->resetAfterTest(true);
+
+        set_config('icon', 'moodle:t/lock', 'auth_oidc');
+        set_config('customicon', '/logo.png', 'auth_oidc');
+
+        utils::migrate_removed_icon_choices();
+
+        $this->assertSame('moodle:t/lock', get_config('auth_oidc', 'icon'));
+        $this->assertSame('/logo.png', get_config('auth_oidc', 'customicon'));
+    }
+
+    /**
+     * A custom icon migrated from a core SVG stock icon can never be published to pix_plugins,
+     * so the repair clears it and restores the default stock icon.
+     *
+     * @return void
+     * @covers \auth_oidc\utils::repair_failed_icon_migration
+     */
+    public function test_repair_failed_icon_migration_clears_unpublishable_icon(): void {
+        global $CFG;
+        $this->resetAfterTest(true);
+
+        $filename = 'migrated_i_permissionlock.svg';
+        $this->create_customicon_file($filename);
+        set_config('customicon', '/' . $filename, 'auth_oidc');
+        unset_config('icon', 'auth_oidc');
+
+        $stalepublished = $CFG->dataroot . '/pix_plugins/auth/oidc/0/customicon.png';
+        check_dir_exists(dirname($stalepublished));
+        file_put_contents($stalepublished, 'stale');
+
+        utils::repair_failed_icon_migration();
+
+        $this->assertEmpty(get_config('auth_oidc', 'customicon'));
+        $this->assertSame('auth_oidc:microsoft_365', get_config('auth_oidc', 'icon'));
+        $this->assertFileDoesNotExist($stalepublished);
+
+        $fs = get_file_storage();
+        $this->assertTrue($fs->is_area_empty(system::instance()->id, 'auth_oidc', 'customicon', 0));
+    }
+
+    /**
+     * A migrated custom icon in a publishable format renders correctly and must be left alone.
+     *
+     * @return void
+     * @covers \auth_oidc\utils::repair_failed_icon_migration
+     */
+    public function test_repair_failed_icon_migration_keeps_publishable_icon(): void {
+        $this->resetAfterTest(true);
+
+        $filename = 'migrated_i_permissionlock.png';
+        $this->create_customicon_file($filename);
+        set_config('customicon', '/' . $filename, 'auth_oidc');
+
+        utils::repair_failed_icon_migration();
+
+        $this->assertSame('/' . $filename, get_config('auth_oidc', 'customicon'));
+    }
+
+    /**
+     * A custom icon that was uploaded by an admin (not produced by the migration) must be left
+     * alone regardless of its extension.
+     *
+     * @return void
+     * @covers \auth_oidc\utils::repair_failed_icon_migration
+     */
+    public function test_repair_failed_icon_migration_ignores_admin_uploads(): void {
+        $this->resetAfterTest(true);
+
+        $this->create_customicon_file('logo.gif');
+        set_config('customicon', '/logo.gif', 'auth_oidc');
+
+        utils::repair_failed_icon_migration();
+
+        $this->assertSame('/logo.gif', get_config('auth_oidc', 'customicon'));
+    }
+
+    /**
+     * Store a file in the auth_oidc customicon file area.
+     *
+     * @param string $filename
+     * @return void
+     */
+    private function create_customicon_file(string $filename): void {
+        get_file_storage()->create_file_from_string([
+            'contextid' => system::instance()->id,
+            'component' => 'auth_oidc',
+            'filearea' => 'customicon',
+            'itemid' => 0,
+            'filepath' => '/',
+            'filename' => $filename,
+        ], 'icon-data');
+    }
+}

--- a/auth/oidc/version.php
+++ b/auth/oidc/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025100603;
+$plugin->version = 2025100603.02;
 $plugin->requires = 2025100600;
 $plugin->release = '5.1.3';
 $plugin->component = 'auth_oidc';


### PR DESCRIPTION
migrate_removed_icon_choices() copied a site's chosen core stock icon into the auth_oidc/customicon file area when that choice was dropped from the icon selector. The removed choices are all generic core Moodle icons, which core now ships as SVG only. auth_oidc_initialize_customicon() deliberately refuses to publish SVG to pix_plugins/ (AUTH_OIDC_CUSTOMICON_ALLOWED_EXTENSIONS), so it returned false without warning: the customicon setting and stored file looked correct, but nothing was written to pix_plugins/ and the login page rendered an empty icon slot. Purging caches did not help because theme_reset_all_caches() is only reached on the success path.

migrate_removed_icon_choices() no longer creates a custom icon. A removed choice with a Microsoft-branded replacement is remapped as before; every other removed choice (a generic core icon with no plugin-specific meaning) now falls back to the default auth_oidc:microsoft_365 stock icon.

repair_failed_icon_migration() undoes the earlier broken migration on sites that already upgraded: it detects a migrated_* custom icon whose extension auth_oidc_initialize_customicon() cannot publish, clears the customicon setting and stored file, removes any stale published file, and restores the default stock icon. It is wired into db/upgrade.php.

auth_oidc_initialize_customicon() now emits a developer debugging() message on the unsupported-extension path instead of failing silently.